### PR TITLE
KMT / H2 Regulated Star formation tests 

### DIFF
--- a/src/enzo/star_maker_h2reg.F
+++ b/src/enzo/star_maker_h2reg.F
@@ -461,7 +461,7 @@ c     starmass_in_Msun/StarFormationMinimumMass.
 
 #ifdef STAR_LOG
                   write(4,*) 'Star particle does not meet minimum ',
-     $                 'mass threshold: ', starmass_in_Msun
+     $                 'mass threshold: ', starmass_in_Msun, 
      $                 dt, timeconstant, 
      $                 gasfrac, starmass, StarFormationMinimumMass
 #endif

--- a/src/enzo/star_maker_h2reg.F
+++ b/src/enzo/star_maker_h2reg.F
@@ -4,7 +4,7 @@
 
 !     set this if you want to log star particle info in a file (one per
 !     processor)
-#define NO_STAR_LOG
+#define STAR_LOG
 
 c=======================================================================
 c////////////////////////  SUBROUTINE STAR_MAKER \\\\\\\\\\\\\\\\\\\\\\\

--- a/src/enzo/star_maker_h2reg.F
+++ b/src/enzo/star_maker_h2reg.F
@@ -462,8 +462,8 @@ c     starmass_in_Msun/StarFormationMinimumMass.
 #ifdef STAR_LOG
                   write(4,*) 'Star particle does not meet minimum ',
      $                 'mass threshold: ', starmass_in_Msun
-c     $                 dt, timeconstant, 
-c     $                 gasfrac, starmass, StarFormationMinimumMass
+     $                 dt, timeconstant, 
+     $                 gasfrac, starmass, StarFormationMinimumMass
 #endif
                      
                   if (StochasticStarFormation .eq. 1) then
@@ -486,6 +486,8 @@ c     $                 gasfrac, starmass, StarFormationMinimumMass
  200                 format(a,a,1pe10.3,a,2(1pe10.3))
 #endif
                   endif
+c                 JT added goto here 112623
+                  goto 10 
                endif
 
 


### PR DESCRIPTION
This branch/PR fixes a bug in the star_makerH2reg.F code that was not applying the minimum mass screen "H2StarMakerMinimumMass". It turns on the star particle creation logging set by the STAR_LOG flag in star_makerH2reg.F. We should leave this on for now and turn it off later when we're confident that the H2-regulated star formation is working as intended. 