### PR TITLE
Fix HydrogrenFractionByMass bug

### DIFF
--- a/src/enzo/GrackleReadParameters.C
+++ b/src/enzo/GrackleReadParameters.C
@@ -247,6 +247,13 @@ int GrackleReadParameters(FILE *fptr, FLOAT InitTime)
     ENZO_FAIL("Error in Grackle initialize_chemistry_data.\n");
   }
 
+  /*
+    Return this value to Enzo's storage as Grackle will change this value during
+    initialization (see Grackle PR #200
+    https://github.com/grackle-project/grackle/pull/200).
+  */
+  CoolData.HydrogenFractionByMass = (float) grackle_data->HydrogenFractionByMass;
+
   // Need to set these after initialize_chemistry_data since
   // that function sets them automatically based on the tables.
   if (FinalRedshift < grackle_data->UVbackground_redshift_off) {

--- a/src/enzo/Grid_GrackleWrapper.C
+++ b/src/enzo/Grid_GrackleWrapper.C
@@ -163,17 +163,6 @@ int grid::GrackleWrapper()
     else if (SNColourNum != -1)
       MetalPointer = BaryonField[SNColourNum];
   } // ENDELSE both metal types
-
-  /*
-    Cap the metal density at 90% of the gas density.
-    This was historically in Enzo, then Grackle and was removed in
-    Grackle PR #121 (https://github.com/grackle-project/grackle/pull/121)
-  */
-  if (MetalPointer != NULL) {
-    for (i = 0; i < size; i++) {
-      MetalPointer[i] = min(MetalPointer[i], 0.9 * BaryonField[DensNum][i]);
-    }
-  }
  
   int temp_thermal = FALSE;
   float *thermal_energy;


### PR DESCRIPTION
This fixes a bug introduced by [Grackle PR #200](https://github.com/grackle-project/grackle/pull/200). This PR changed the way HydrogenFractionByMass takes its default value, first setting it to FLOAT_UNDEFINED, detecting that, and then setting it to 0.76. This leaves Enzo's internal version of this parameter set to FLOAT_UNDEFINED which has catastrophic consequences almost immediately within Enzo. This fixes that by pulling Grackle's version of this parameter back to Enzo so they are in sync.

I have also reverted change from PR #24 as we are no longer confident this is the issue.