### PR TITLE
Remove H2StarMakerMinimumMass as a separate parameter

### DIFF
--- a/doc/manual/source/parameters/index.rst
+++ b/doc/manual/source/parameters/index.rst
@@ -2501,7 +2501,8 @@ The parameters below are considered in ``StarParticleCreation`` method 11.
 ``H2StarMakerNumberDensityThreshold`` (external)
     See :ref:`molecular_hydrogen_regulated_star_formation`.
 ``H2StarMakerMinimumMass`` (external)
-    See :ref:`molecular_hydrogen_regulated_star_formation`.
+    **Deprecated** in favor of ``StarMakerMinimumMass``.
+    You can still set this parameter; however, it will overwrite ``StarMakerMinimumMass``.
 ``H2StarMakerMinimumH2FractionForStarFormation`` (external)
     See :ref:`molecular_hydrogen_regulated_star_formation`.
 ``H2StarMakerStochastic`` (external)

--- a/doc/manual/source/physics/star_particles.rst
+++ b/doc/manual/source/physics/star_particles.rst
@@ -686,12 +686,12 @@ This results in fewer and
 more massive star particles, which improves computational
 efficiency. Even so, it may be desirable to enforce a lower limit to
 the star particle mass in some cases. This can be done with the
-parameter ``H2StarMakerMinimumMass``, below which star particles are
+parameter ``StarMakerMinimumMass``, below which star particles are
 not created. However, with ``H2StarMakerStochastic``, if the
-stellar mass is less than H2StarMakerMinimumMass, then a star
-particle of mass equal to H2StarMakerMinimumMass is formed
+stellar mass is less than StarMakerMinimumMass, then a star
+particle of mass equal to StarMakerMinimumMass is formed
 stochastically with a probability of (stellar
-mass)/H2StarMakerMinimumMass.
+mass)/StarMakerMinimumMass.
 
 For some applications, it may be desireable to create stars only 
 at local density peaks. For this purpose, setting 

--- a/src/enzo/ReadParameterFile.C
+++ b/src/enzo/ReadParameterFile.C
@@ -2202,8 +2202,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
   }
 
   if (H2StarMakerMinimumMass > 0) { // non-default
-    fprintf(stderr,"WARNING: Use of H2StarMakerMinimumMass is deprecated. Copying the supplied value to StarMakerMinimumMass instead.");
-    StarMakerMinimumMass = H2StarMakerMinimumMass;
+    ENZO_FAIL("Use of H2StarMakerMinimumMass is deprecated. Please use StarMakerMinimumMass instead.");
   }
   /* Allow StarMakerMinimumMass to set H2StarMakerMinimumMass
      so I don't have to rewrite a bunch of code. */

--- a/src/enzo/ReadParameterFile.C
+++ b/src/enzo/ReadParameterFile.C
@@ -2201,6 +2201,14 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     }
   }
 
+  if (H2StarMakerMinimumMass > 0) { // non-default
+    fprintf(stderr,"WARNING: Use of H2StarMakerMinimumMass is deprecated. Copying the supplied value to StarMakerMinimumMass instead.");
+    StarMakerMinimumMass = H2StarMakerMinimumMass;
+  }
+  /* Allow StarMakerMinimumMass to set H2StarMakerMinimumMass
+     so I don't have to rewrite a bunch of code. */
+  H2StarMakerMinimumMass = StarMakerMinimumMass;
+
   // Tracer fluid tests
   if(UseTracerFluid > 0){
     if(NumberOfTracerFluidFields < 1)

--- a/src/enzo/WriteParameterFile.C
+++ b/src/enzo/WriteParameterFile.C
@@ -1127,7 +1127,6 @@ int WriteParameterFile(FILE *fptr, TopGridData &MetaData, char *name = NULL)
   fprintf(fptr, "H2StarMakerH2FractionMethod        = %"ISYM"\n", H2StarMakerH2FractionMethod);
   fprintf(fptr, "H2StarMakerEfficiency              = %"GSYM"\n", H2StarMakerEfficiency);
   fprintf(fptr, "H2StarMakerNumberDensityThreshold  = %"GSYM"\n", H2StarMakerNumberDensityThreshold);
-  fprintf(fptr, "H2StarMakerMinimumMass             = %"GSYM"\n", H2StarMakerMinimumMass);
   fprintf(fptr, "H2StarMakerMinimumH2FractionForStarFormation = %"GSYM"\n", H2StarMakerMinimumH2FractionForStarFormation);
   fprintf(fptr, "H2StarMakerStochastic              = %"ISYM"\n", H2StarMakerStochastic);
   fprintf(fptr, "H2StarMakerUseSobolevColumn        = %"ISYM"\n", H2StarMakerUseSobolevColumn);


### PR DESCRIPTION
The existence of both `StarMakerMinimumMass` and `H2StarMakerMinimumMass` is not strictly necessary and prevents the H2-regulated star formation method from easily benefiting from recent machinery that allows `StarMakerMinimumMass` to vary over both time and space.

Without rewriting a lot of code, this PR removes `H2StarMakerMinimumMass` by pining it's value to that of `StarMakerMinimumMass`. For backwards compatibility, users may still specify `H2StarMakerMinimumMass` in their initial parameter files but this will be used to overwrite `StarMakerMinimumMass` (and a warning will be thrown to `stderr`). No longer will `H2StarMakerMinimumMass` be written out to dataset parameter files.

This effectively accomplishes the same goal as PR #29 with less bookkeeping.