### PR TITLE
Fix for StarMakerMinimumMass being set to FLOAT_UNDEFINED if MultiRefineRegionSpatiallyVaryingStarMass isn't in use

### DIFF
--- a/src/enzo/EvolveHierarchy.C
+++ b/src/enzo/EvolveHierarchy.C
@@ -538,8 +538,10 @@ int EvolveHierarchy(HierarchyEntry &TopGrid, TopGridData &MetaData,
         return FAIL;
     }
 
-/* Now that we've formed stars, reset this to original value */
-StarMakerMinimumMass = MultiRefineRegionDefaultStarMass;
+/* Now that we've formed stars, reset this to original value if we changed it */
+if (MultiRefineRegionSpatiallyVaryingStarMass > 0){
+  StarMakerMinimumMass = MultiRefineRegionDefaultStarMass;
+}
 
 #ifdef USE_MPI 
     CommunicationBarrier();


### PR DESCRIPTION
StarMakerMinimumMass was being set to MultiRefineRegionDefaultStarMass in EvolveHierarchy, regardless of whether or not context-aware star formation was turned on. If context-aware star formation is not on, this means StarMakerMinimumMass gets set to FLOAT_UNDEFINED, which is far from ideal. I added an if statement to check whether CASF is on before the reset happens. All credit to @clochhaas for identifying what was going on!