### PR TITLE
Updated Aitken Milan machine file

### DIFF
--- a/src/enzo/Make.mach.nasa-aitken-milan
+++ b/src/enzo/Make.mach.nasa-aitken-milan
@@ -1,8 +1,8 @@
 #=======================================================================
 #
-# FILE:        Make.mach.nasa-aitken-rome
+# FILE:        Make.mach.nasa-aitken-milan
 #
-# DESCRIPTION: Makefile settings for NASA's pleiades
+# DESCRIPTION: Makefile settings for NASA's Aitken Milan nodes
 #
 #    modules: module use -a /nasa/modulefiles/testing
 #             comp-intel/2020.4.304
@@ -16,14 +16,14 @@
 # DATE:        2025-09-08 
 #=======================================================================
 
-MACH_TEXT  = NASA Aitken Rome
+MACH_TEXT  = NASA Aitken Milan
 MACH_VALID = 1
-MACH_FILE  = Make.mach.nasa-aitken-rome
+MACH_FILE  = Make.mach.nasa-aitken-milan
 
-MACHINE_NOTES = "MACHINE_NOTES for Aitken Rome nodes at NASA: \
+MACHINE_NOTES = "MACHINE_NOTES for Aitken Milan nodes at NASA: \
         The following modules are needed to compile: \
             module use -a /nasa/modulefiles/testing \
-            module load comp-intel/2025.2.1 mpi-hpe/mpt.2.23 hdf5/1.8.18_serial"
+            module load comp-intel/2020.4.304 mpi-hpe/mpt.2.23 hdf5/1.8.18_serial"
 
 #-----------------------------------------------------------------------
 # Install paths (local variables)
@@ -32,8 +32,9 @@ MACHINE_NOTES = "MACHINE_NOTES for Aitken Rome nodes at NASA: \
 LOCAL_MPI_INSTALL    = /nasa/modulefiles/sles15/mpi-hpe/mpt.2.23
 LOCAL_HDF5_INSTALL   = /nasa/modulefiles/sles15/hdf5/1.8.18_serial
 LOCAL_PYTHON_INSTALL = $(YT_DEST)
-LOCAL_COMPILER_DIR    = /nasa/modulefiles/testing/comp-intel/2025.2.1
-LOCAL_GRACKLE_INSTALL = /u/jtumlins/grackle/grackle-3.3.1-dev/build
+LOCAL_COMPILER_DIR    = /nasa/intel/Compiler/2020.4.304/
+# Change to your own GRACKLE install:
+LOCAL_GRACKLE_INSTALL = /nobackup/clochhaa/grackle/build/
 
 
 #-----------------------------------------------------------------------
@@ -117,7 +118,8 @@ MACH_INCLUDES_HYPRE   = $(LOCAL_INCLUDES_HYPRE)
 
 LOCAL_LIBS_MPI    = -L$(LOCAL_MPI_INSTALL)/lib -lmpi -lmpi++
 LOCAL_LIBS_HDF5   = -L$(LOCAL_HDF5_INSTALL)/lib -lhdf5 -lz
-LOCAL_LIBS_LZ     = -L/u/mpeeples/miniconda3/lib -lz
+# Change to your own python install:
+LOCAL_LIBS_LZ     = -L/nobackup/clochhaa/miniconda3/lib -lz
 LOCAL_LIBS_GRACKLE = -L$(LOCAL_GRACKLE_INSTALL)/lib64 -lgrackle
 
 LOCAL_LIBS_MACH = -lifcore -lifport


### PR DESCRIPTION
Cleaned up comments and fixed compiler version in Make.mach.nasa-aitken-milan. Tested and enzo-foggie successfully compiles on the Milan nodes using this Makefile.