### PR TITLE
Fixed incorrect capping on metal fraction in mechanical feedback routine

### DIFF
--- a/src/enzo/star_feedback6.F
+++ b/src/enzo/star_feedback6.F
@@ -966,7 +966,7 @@ c
                do k = -1_IKIND,1_IKIND
                   do j = -1_IKIND,1_IKIND
                      do i = -1_IKIND,1_IKIND
-                        Z_cell = metal(ic+i,jc+j,kc+k)
+                        Z_cell = metal(ic+i,jc+j,kc+k)/d(ic+i,jc+j,kc+k)
                         mu_cell = mu(ic+i,jc+j,kc+k)
 c
 c     The following adjustments to Z_cell and mu_cell are band-aids to


### PR DESCRIPTION
Claire pointed out that I was using metal density when I actually wanted metal fraction in the check that caps the metal fraction of any cell at 0.95 so that nothing goes wonky. Fixed this.

Note that because the metallicity is a parameter in determining the momentum to inject, it's possible that this has actually been having a big effect.