### PR TITLE
[WIP] Energy-based mesh refinement 

### DIFF
--- a/src/enzo/Grid.h
+++ b/src/enzo/Grid.h
@@ -971,6 +971,10 @@ gradient force to gravitational force for one-zone collapse test. */
 
    int FlagCellsToBeRefinedByCoolingTime();
 
+/* Flag "hot" cells whose mass is above a threshold. */
+
+   int FlagCellsToBeRefinedByTemperature();
+
 /* Flag particles within the MustRefineParticles region as MustRefine Particles */
    int MustRefineParticlesFlagInRegion();
 

--- a/src/enzo/Grid_FlagCellsToBeRefinedByTemperature.C
+++ b/src/enzo/Grid_FlagCellsToBeRefinedByTemperature.C
@@ -1,0 +1,105 @@
+/***********************************************************************
+/
+/  GRID CLASS (FLAG CELLS TO BE REFINED WHERE COOLING TIME < DX/CSOUND)
+/
+/  written by: Greg Bryan
+/  date:       February, 2000
+/  modified1:
+/
+/  PURPOSE:
+/
+/  RETURNS:
+/    number of flagged cells, or -1 on failure
+/
+************************************************************************/
+ 
+#include <stdio.h>
+#include <math.h>
+#include "ErrorExceptions.h"
+#include "macros_and_parameters.h"
+#include "typedefs.h"
+#include "global_data.h"
+#include "Fluxes.h"
+#include "GridList.h"
+#include "ExternalBoundary.h"
+#include "Grid.h"
+#include "phys_constants.h"
+
+int GetUnits(float *DensityUnits, float *LengthUnits,
+         float *TemperatureUnits, float *TimeUnits,
+         float *VelocityUnits, FLOAT Time);
+ 
+ 
+int grid::FlagCellsToBeRefinedByTemperature()
+{
+  /* declarations */
+ 
+  int i, dim;
+ 
+  /* Return if this grid is not on this processor. */
+ 
+  if (MyProcessorNumber != ProcessorNumber)
+    return SUCCESS;
+ 
+  /* error check */
+ 
+  if (FlaggingField == NULL) {
+    fprintf(stderr, "Flagging Field is undefined.\n");
+    return -1;
+  }
+
+  /* compute size */
+ 
+  int size = 1;
+  for (dim = 0; dim < GridRank; dim++)
+    size *= GridDimension[dim];
+ 
+  /* Compute the temperature field. */
+ 
+  float *temperature = NULL;
+  temperature = new float[size];
+  if (this->ComputeTemperatureField(temperature) == FAIL)
+    ENZO_FAIL("Error in grid->ComputeTemperature.");
+
+  /* Get units. */
+
+  float DensityUnits=1, LengthUnits=1, VelocityUnits=1, TimeUnits=1,
+    TemperatureUnits=1;
+
+  if (GetUnits(&DensityUnits, &LengthUnits, &TemperatureUnits,
+            &TimeUnits, &VelocityUnits, Time) == FAIL) {
+    ENZO_FAIL("Error in GetUnits.\n");
+  }
+
+  /* Find fields: density, total energy, velocity1-3. */
+ 
+  int DensNum, GENum, TENum, Vel1Num, Vel2Num, Vel3Num;
+  if (this->IdentifyPhysicalQuantities(DensNum, GENum, Vel1Num, Vel2Num,
+				       Vel3Num, TENum) == FAIL) {
+    ENZO_FAIL("Error in IdentifyPhysicalQuantities.\n");
+  }
+
+  /* Loop over grid, checking if temperature > threshold and mass > threshold */
+
+  float cell_mass, cell_vol = pow(CellWidth[0][0] * LengthUnits, 3);
+  for (i = 0; i < size; i++) {
+    cell_mass = BaryonField[DensNum][i] * DensityUnits * cell_vol / SolarMass;
+    if (temperature[i] > MinimumTemperatureForRefinement && cell_mass > TemperatureRefinementStoppingMassMsun)
+      FlaggingField[i]++;
+  }
+
+  /* clean up */
+ 
+  delete [] temperature;
+ 
+  /* Count number of flagged Cells. */
+ 
+  int NumberOfFlaggedCells = 0;
+  for (i = 0; i < size; i++)
+    if (FlaggingField[i] > 0)
+
+      NumberOfFlaggedCells++;
+ 
+  return NumberOfFlaggedCells;
+ 
+}

--- a/src/enzo/Grid_SetFlaggingField.C
+++ b/src/enzo/Grid_SetFlaggingField.C
@@ -287,6 +287,11 @@ int grid::SetFlaggingField(int &NumberOfFlaggedCells, int level)
 	  return FAIL;
 	}
 	break;
+
+      case 21:
+        /* THIS IS WHERE WE WILL PUT THE ENERGY REFINEMENT */
+
+
 	
 	/* ==== METHOD 100: UNDO REFINEMENT IN SOME REGIONS ==== */
 	

--- a/src/enzo/Grid_SetFlaggingField.C
+++ b/src/enzo/Grid_SetFlaggingField.C
@@ -289,7 +289,11 @@ int grid::SetFlaggingField(int &NumberOfFlaggedCells, int level)
 	break;
 
       case 21:
-        /* THIS IS WHERE WE WILL PUT THE ENERGY REFINEMENT */
+	NumberOfFlaggedCells = this->FlagCellsToBeRefinedByTemperature();
+	if (NumberOfFlaggedCells < 0) {
+	  fprintf(stderr, "Error in grid->FlagCellsToBeRefinedByTemperature.\n");
+	  return FAIL;
+	}
 
 
 	

--- a/src/enzo/Grid_SetFlaggingField.C
+++ b/src/enzo/Grid_SetFlaggingField.C
@@ -294,6 +294,7 @@ int grid::SetFlaggingField(int &NumberOfFlaggedCells, int level)
 	  fprintf(stderr, "Error in grid->FlagCellsToBeRefinedByTemperature.\n");
 	  return FAIL;
 	}
+	break;
 
 
 	

--- a/src/enzo/Make.config.objects
+++ b/src/enzo/Make.config.objects
@@ -493,6 +493,7 @@ OBJS_CONFIG_LIB = \
         Grid_FlagCellsToAvoidRefinementRegion.o \
 	Grid_FlagCellsToBeRefinedByCoolingTime.o \
 	Grid_FlagCellsToBeRefinedByJeansLength.o \
+        Grid_FlagCellsToBeRefinedByTemperature.o \
 	Grid_FlagCellsToBeRefinedByTotalJeansLength.o \
 	Grid_FlagCellsToBeRefinedByMass.o \
 	Grid_FlagCellsToBeRefinedByMetallicity.o \

--- a/src/enzo/ReadParameterFile.C
+++ b/src/enzo/ReadParameterFile.C
@@ -371,6 +371,10 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 		  &MetallicityRefinementMinMetallicity);
     ret += sscanf(line, "MetallicityRefinementMinDensity = %"FSYM,
 		  &MetallicityRefinementMinDensity);
+    ret += sscanf(line, "MinimumTemperatureForRefinement = %"FSYM,
+      &MinimumTemperatureForRefinement);
+    ret += sscanf(line, "TemperatureRefinementStoppingMassMsun = %"FSYM,
+      &TemperatureRefinementStoppingMassMsun);
 
     ret += sscanf(line, "DomainLeftEdge        = %"PSYM" %"PSYM" %"PSYM, DomainLeftEdge,
 		  DomainLeftEdge+1, DomainLeftEdge+2);

--- a/src/enzo/SetDefaultGlobalValues.C
+++ b/src/enzo/SetDefaultGlobalValues.C
@@ -206,6 +206,9 @@ int SetDefaultGlobalValues(TopGridData &MetaData)
   MetallicityRefinementMinDensity = FLOAT_UNDEFINED;
   FluxCorrection            = TRUE;
 
+  MinimumTemperatureForRefinement = 1e5;  // K
+  TemperatureRefinementStoppingMassMsun = 100;
+
   UseCoolingTimestep = FALSE;
   CoolingTimestepSafetyFactor = 0.1;
 

--- a/src/enzo/WriteParameterFile.C
+++ b/src/enzo/WriteParameterFile.C
@@ -372,6 +372,10 @@ int WriteParameterFile(FILE *fptr, TopGridData &MetaData, char *name = NULL)
 	  MetallicityRefinementMinMetallicity);
   fprintf(fptr, "MetallicityRefinementMinDensity     = %"GSYM"\n", 
 	  MetallicityRefinementMinDensity);
+  fprintf(fptr, "MinimumTemperatureForRefinement       = %"GSYM"\n",
+    MinimumTemperatureForRefinement);
+  fprintf(fptr, "TemperatureRefinementStoppingMassMsun = %"GSYM"\n",
+    TemperatureRefinementStoppingMassMsun);
  
   fprintf(fptr, "DomainLeftEdge         = ");
   WriteListOfFloats(fptr, MetaData.TopGridRank, DomainLeftEdge);

--- a/src/enzo/global_data.h
+++ b/src/enzo/global_data.h
@@ -192,6 +192,10 @@ EXTERN int MetallicityRefinementMinLevel;
 EXTERN float MetallicityRefinementMinMetallicity;
 EXTERN float MetallicityRefinementMinDensity;
 
+/* thresholds for FlagGridCellsToBeRefinedByTemperature */
+EXTERN float MinimumTemperatureForRefinement;
+EXTERN float TemperatureRefinementStoppingMassMsun;
+
 /* Velocity to limit timesteps */
 
 EXTERN float TimestepSafetyVelocity;


### PR DESCRIPTION
This is a **work in progress PR** addressing issue #44 - the need to add an energy-based AMR criterion for the FOGGIE 2.0 simulations. This is probably going to be relatively straightforward to implement, but will ultimately build on PR #45 (the "multi refine region consolidation and cleanup" PR) and thus **it should not be merged until PR #45 is complete**.

@bwoshea is responsible for this PR. (The main reason this PR is being added right now is so we can add notes and get feedback to prepare for the Flatiron code sprint in December.)  **Please add suggestions/questions/comments relating to the implementation of this refinement method to issue #44** ; discussion in this PR should focus on the actual implementation.

**PR Checklist**

- [ ] New features are documented with narrative docs.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.