### PR TITLE
Add tracer fluid handling in Flux correction and Star formation

### DIFF
--- a/src/enzo/Grid_CorrectForRefinedFluxes.C
+++ b/src/enzo/Grid_CorrectForRefinedFluxes.C
@@ -406,7 +406,9 @@ int grid::CorrectForRefinedFluxes(fluxes *InitialFluxes,
             )
             || FieldType[field] == MetalSNIaDensity
             || FieldType[field] == MetalSNIIDensity
-          )
+			|| (FieldType[field] >= MetalAGBDensity &&
+		        FieldType[field] <= TracerFluidField08Density)
+        	)
           && FieldTypeNoInterpolate(FieldType[field]) == FALSE
           && FieldTypeIsRadiation(FieldType[field]) == FALSE
         ) {
@@ -854,7 +856,10 @@ int grid::CorrectForRefinedFluxes(fluxes *InitialFluxes,
 	    if ( ((FieldType[field] >= ElectronDensity &&
 		   FieldType[field] <= ExtraType1) ||
 		  FieldType[field] == MetalSNIaDensity ||
-		  FieldType[field] == MetalSNIIDensity) &&
+		  FieldType[field] == MetalSNIIDensity
+			|| (FieldType[field] >= MetalAGBDensity &&
+		        FieldType[field] <= TracerFluidField08Density)
+		) &&
 		 FieldTypeNoInterpolate(FieldType[field]) == FALSE &&
 		 FieldTypeIsRadiation(FieldType[field]) == FALSE)
 	      for (k = Start[2]; k <= End[2]; k++)

--- a/src/enzo/Grid_CorrectForRefinedFluxes.C
+++ b/src/enzo/Grid_CorrectForRefinedFluxes.C
@@ -365,8 +365,12 @@ int grid::CorrectForRefinedFluxes(fluxes *InitialFluxes,
       // like density, total energy, and internal energy
       if (FluxCorrection == 2){
         for (field = 0; field < NumberOfBaryonFields; field++) {
-          if (FieldType[field] >= ElectronDensity &&
-              FieldType[field] <= ExtraType1) {
+          if ((FieldType[field] >= ElectronDensity &&
+               FieldType[field] <= ExtraType1) ||
+              FieldType[field] == MetalSNIaDensity ||
+              FieldType[field] == MetalSNIIDensity ||
+              (FieldType[field] >= MetalAGBDensity &&
+               FieldType[field] <= TracerFluidField08Density)) {
             fieldNumberList.push_back(field);
           }
         }

--- a/src/enzo/Grid_StarParticleHandler.C
+++ b/src/enzo/Grid_StarParticleHandler.C
@@ -726,7 +726,8 @@ int grid::StarParticleHandler(HierarchyEntry* SubgridPointer, int level,
  
   for (field = 0; field < NumberOfBaryonFields; field++)
     if ((FieldType[field] >= ElectronDensity && FieldType[field] <= ExtraType1) ||
-	FieldType[field] == MetalSNIaDensity || FieldType[field] == MetalSNIIDensity)
+	FieldType[field] == MetalSNIaDensity || FieldType[field] == MetalSNIIDensity ||
+    (FieldType[field] >= MetalAGBDensity && FieldType[field] <= TracerFluidField08Density))
 #ifdef EMISSIVITY
       /* 
          it used to be set to  FieldType[field] < GravPotential if Geoffrey's Emissivity0
@@ -2264,7 +2265,8 @@ int grid::StarParticleHandler(HierarchyEntry* SubgridPointer, int level,
  
   for (field = 0; field < NumberOfBaryonFields; field++) {
     if ((FieldType[field] >= ElectronDensity && FieldType[field] <= ExtraType1) ||
-	FieldType[field] == MetalSNIaDensity || FieldType[field] == MetalSNIIDensity) {
+	FieldType[field] == MetalSNIaDensity || FieldType[field] == MetalSNIIDensity ||
+       (FieldType[field] >= MetalAGBDensity && FieldType[field] <= TracerFluidField08Density)) {
 #ifdef EMISSIVITY
       /* 
          it used to be set to  FieldType[field] < GravPotential if Geoffrey's Emissivity0


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request to help us improve
title: ''
labels: ''
assignees: ''

---




Thank you so much for your PR! To help us review, fill out the form to the best of your ability.  Please make use of the development guide at https://enzo.readthedocs.io/en/latest/developer_guide/ModificationIntro.html#how-to-develop-enzo

**These some minor changes I suggested. We need to add tracers to conserve the total amount of tracer fluid (and metals) inGrid_CorrectForRefinedFluxes.C. The part in Grid_StarParticleHandler.C is more tricky. Adding new fields in that routine keeps the mass fraction unchanged (which is what I changed), but it cannot capture the pollution of fields by stellar feedback and assumes they have the identical metallicity or tracers as the ambient cell.**

Provide a general summary of your changes in the title above, for example "Fixes crash in FluxCorrection between AMR levels".  Please avoid non-descriptive titles such as "Addresses issue #42."

If you are able to do so, please do not create the PR out of main, but out of a separate branch.

**Describe your pull request**

Please provide at least 1-2 sentences describing the pull request in detail.  Why is this change required?  What problem does it solve?

If it fixes an open issue, please link to the issue here.  Github will [autolink](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls) if prefixed with a hash, e.g. #42.

If your PR depends on another PR, please link to the PR here [github autolinking syntax](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls).

[ ] This is a major change or addition.  Will require two reviewers.

**PR Checklist**

Note that some of these check boxes may not apply to all pull requests.

- [ ] New features are documented with narrative docs.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

**Thank you!**

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding, or if you would like help in
addressing a reviewer's comments.  Lastly, please ping us if you've been waiting
too long to hear back on your PR.
