### PR TITLE
Fix memory leak with Initial Particle Mass and others

### DIFF
--- a/src/enzo/Grid_DepositMustRefineParticles.C
+++ b/src/enzo/Grid_DepositMustRefineParticles.C
@@ -95,7 +95,8 @@ int grid::DepositMustRefineParticles(int pmethod, int level, bool KeepFlaggingFi
   bool *antirules;
   int *AntiFlaggingField;
   int NumberOfAntiRules = 0;
-  antirules = new bool[NumberOfAntiRules];
+  if (NumberOfAntiRules > 0)
+    antirules = new bool[NumberOfAntiRules];
 
   // Add an antirule to unflag over-refined dark matter particles.
   if (MustRefineParticlesCreateParticles == 4) {

--- a/src/enzo/Grid_DepositMustRefineParticles.C
+++ b/src/enzo/Grid_DepositMustRefineParticles.C
@@ -95,8 +95,6 @@ int grid::DepositMustRefineParticles(int pmethod, int level, bool KeepFlaggingFi
   bool *antirules;
   int *AntiFlaggingField;
   int NumberOfAntiRules = 0;
-  if (NumberOfAntiRules > 0)
-    antirules = new bool[NumberOfAntiRules];
 
   // Add an antirule to unflag over-refined dark matter particles.
   if (MustRefineParticlesCreateParticles == 4) {

--- a/src/enzo/Grid_destructor.C
+++ b/src/enzo/Grid_destructor.C
@@ -122,6 +122,7 @@ grid::~grid()
   delete BoundaryFluxes;
  
   delete [] ParticleMass;
+  if (StarMakerStoreInitialMass) delete [] ParticleInitialMass;
   delete [] ParticleNumber;
   delete [] ParticleType;
   delete [] PotentialField;

--- a/src/enzo/ReadParameterFile.C
+++ b/src/enzo/ReadParameterFile.C
@@ -2115,24 +2115,12 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     ENZO_FAIL("Cannot select GlobalDir AND LocalDir!\n");
   }
 
-  char *cwd_buffer = new char[MAX_LINE_LENGTH];
-  size_t cwd_buffer_len = MAX_LINE_LENGTH;
-
   if ( (MetaData.GlobalDir == NULL) && (MetaData.LocalDir == NULL) ) {
-    /*if(getcwd(cwd_buffer, cwd_buffer_len) == NULL) {
-      fprintf(stderr, "GETCWD call FAILED\n");
-    }
+      MetaData.GlobalDir = new char[MAX_LINE_LENGTH];
+      strcpy(MetaData.GlobalDir, ".");
     if (MyProcessorNumber == ROOT_PROCESSOR)
-      fprintf(stderr,"CWD %s\n", cwd_buffer);
-    */
-    /* No one seems to want GlobalDir to default to abspath(CWD).  I'm leaving
-       the code here in case you do. MJT */
-    strcpy(cwd_buffer, ".");
-    MetaData.GlobalDir = cwd_buffer;
-    if (MyProcessorNumber == ROOT_PROCESSOR)
-      fprintf(stderr,"Global Dir set to %s\n", cwd_buffer);
+      fprintf(stderr,"Global Dir set to %s\n", MetaData.GlobalDir);
   }
-  delete [] cwd_buffer;
 
 #ifdef USE_UUID
   /* Generate unique identifier if one wasn't found. */

--- a/src/enzo/ReadParameterFile.C
+++ b/src/enzo/ReadParameterFile.C
@@ -2132,6 +2132,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     if (MyProcessorNumber == ROOT_PROCESSOR)
       fprintf(stderr,"Global Dir set to %s\n", cwd_buffer);
   }
+  delete [] cwd_buffer;
 
 #ifdef USE_UUID
   /* Generate unique identifier if one wasn't found. */


### PR DESCRIPTION
I found a few memory leaks in Enzo while searching for the leak related to the Initial Particle Mass. I've gone ahead and fixed these and the test suite passes.