### PR TITLE
Fix longstanding issue with np

### DIFF
--- a/bin/np
+++ b/bin/np
@@ -189,6 +189,7 @@ sub parseOutput {
 	  $hierarchy{"Levels"}[$level]{"iterations"} = $iterations;
 	  $processLevel = $level;
 	  $processStatus = '.';
+	  $hierarchy{maxLevel} = $hierarchy{rh_last_level};
 	  $update = 1;
       }
       elsif ($line =~ /^WriteAllData/) {
@@ -206,6 +207,7 @@ sub parseOutput {
       elsif (($line =~ /^RebuildHierarchy\: level = (\d+)/) ||
 	     ($line =~ /^RebuildHierarchy\[(\d+)\]\:/)) {
 	  my $level = $1;
+	  $hierarchy{rh_last_level} = $level;
 	  $processLevel = $level;
 	  $processStatus = 'R';
 	  if ($line =~ /Flagged\s+\d+\/(\d+)/) {


### PR DESCRIPTION
This change makes np guess the current maximum level of refinement based on the last level at which RebuildHierarchy was called. This allows the progress between snapshots to be updated correctly if derefinement has happened and the maximum level has decreased. Previously, the Completed percentage would get stuck at however far the max level had gone before it had disappeared. Now you don't have to wonder why it's been 18 hours and the simulation is only 0.02% of the way to the next snapshot. It has bugged me for 18 years.