### PR TITLE
Faster table lookups for feedback

### DIFF
--- a/doc/manual/source/physics/star_particles.rst
+++ b/doc/manual/source/physics/star_particles.rst
@@ -996,6 +996,9 @@ SYGMA parameters such as the IMF, nucleosynthetic yield tables, Type II SNe mass
 and Type Ia SNe delay time distribution can be set by modifying the ``params`` dictionary
 at the top of ``chemical_feedback.py``. Additional parameters supported by SYGMA can also
 be added to this dictionary; see the `SYGMA documentation <https://nugrid.github.io/NuPyCEE/SPHINX/build/html/sygma.html>`_.
+Be advised that Enzo expects the table to contain population ages that are evenly spaced
+in log space. You should therefore not change the type of timestepping used for generating
+the table (though you are free to change the number of intervals used).
 
 The script for combining pre-SN feedback yield tables for stellar winds from Starburst99 
 is provided as a Jupyter notebook in ``input/combine_pySB_hdf5.ipynb``. You will need numpy and h5py

--- a/src/enzo/tabular_feedback.F
+++ b/src/enzo/tabular_feedback.F
@@ -775,7 +775,7 @@ c      Locals
 c 
       INTG_PREC z_ub, a1_ub, a2_ub ! table index right bounds (for interp)
       R_PREC age1, age2            ! time integration bounds
-      R_PREC dtab_age_log          ! for finding age indices
+      R_PREC age_start_log, dage_log  ! for finding age indices
       R_PREC rate1, rate2, t1, t2 
 c 
 c      Set time integration bounds
@@ -793,18 +793,18 @@ c     Metallicity indices are not regular but are few in number (~8)
          z_ub = z_ub + 1_IKIND
       enddo
 c     Ages are many but are regularly spaced in log space so the
-c     indicies can be found algebraically. First index is zero. The max 
-c     expression return the lower bound so we add 1 to find
+c     indicies can be found algebraically.
+c     First index is zero so our line equation starts at index 2.
+c     The expression return the lower bound so we add 1 to find
 c     the upper bound. This way I don't have to rewrite any of
 c     the following logic. 
-      dtab_age_log = log10(tab_age(3)) - log10(tab_age(2))
-      a1_ub = int((log10(age1))/dtab_age_log, IKIND)+1
-      a2_ub = int((log10(age2))/dtab_age_log, IKIND)+1
+      age_start_log = log10(tab_age(2))
+      dage_log = log10(tab_age(3)) - log10(tab_age(2))
+      a1_ub = int((log10(age1)-age_start_log)/dage_log + 2, IKIND)+1
+      a2_ub = int((log10(age2)-age_start_log)/dage_log + 2, IKIND)+1
 c     Correct for log10(0)=-inf case
       if (age1 .le. 0) a1_ub = 1_IKIND
       if (age2 .le. 0) a2_ub = 1_IKIND
-      write(*,*) '    dtab_age_log, age1, age2:', dtab_age_log, age1, age2
-      write(*,*) '    a1_ub, a2_ub:', a1_ub, a2_ub
 c 
 c      If particle falls outside of age table, exit
 c 

--- a/src/enzo/tabular_feedback.F
+++ b/src/enzo/tabular_feedback.F
@@ -804,11 +804,16 @@ c     the upper bound. This way I don't have to rewrite any of
 c     the following logic. 
       age_start_log = log10(tab_age(2))
       dage_log = log10(tab_age(3)) - log10(tab_age(2))
-      a1_ub = int((log10(age1)-age_start_log)/dage_log + 2, IKIND)+1
-      a2_ub = int((log10(age2)-age_start_log)/dage_log + 2, IKIND)+1
-c     Correct for log10(0)=-inf case
-      if (age1 .le. 0) a1_ub = 1_IKIND
-      if (age2 .le. 0) a2_ub = 1_IKIND
+      if (age1 .le. tab_age(2)) then 
+            a1_ub = 1_IKIND
+      else
+            a1_ub = int((log10(age1)-age_start_log)/dage_log+2, IKIND)+1
+      endif
+      if (age2 .le. tab_age(2)) then
+            a2_ub = 1_IKIND
+      else 
+            a2_ub = int((log10(age2)-age_start_log)/dage_log+2, IKIND)+1
+      endif
 c 
 c      If particle falls outside of age table, exit
 c 

--- a/src/enzo/tabular_feedback.F
+++ b/src/enzo/tabular_feedback.F
@@ -775,7 +775,7 @@ c      Locals
 c 
       INTG_PREC z_ub, a1_ub, a2_ub ! table index right bounds (for interp)
       R_PREC age1, age2            ! time integration bounds
-      R_PREC tab_age_start_log, dtab_age_log  ! for finding age indices
+      R_PREC dtab_age_log          ! for finding age indices
       R_PREC rate1, rate2, t1, t2 
 c 
 c      Set time integration bounds
@@ -792,17 +792,17 @@ c     Metallicity indices are not regular but are few in number (~8)
      &          .and. z_ub .lt. ntab_metal)
          z_ub = z_ub + 1_IKIND
       enddo
-c     Ages are many but are regularly spaced in log space.
-c     Indicies can be found algebraically. The max 
+c     Ages are many but are regularly spaced in log space so the
+c     indicies can be found algebraically. First index is zero. The max 
 c     expression return the lower bound so we add 1 to find
 c     the upper bound. This way I don't have to rewrite any of
 c     the following logic. 
-      tab_age_start_log = log10(tab_age(1))
-      dtab_age_log = log10(tab_age(2)) - tab_age_start_log
+      dtab_age_log = log10(tab_age(3)) - log10(tab_age(2))
       a1_ub = max( 1,
-     & int((log10(age1)-tab_age_start_log)/dtab_age_log, IKIND)+1 )+1
+     & int((log10(age1))/dtab_age_log, IKIND)+1 )+1
       a2_ub = max( 1,
-     & int((log10(age2)-tab_age_start_log)/dtab_age_log, IKIND)+1 )+1
+     & int((log10(age2))/dtab_age_log, IKIND)+1 )+1
+      write(*,*) '    a1_ub = ', a1_ub, 'a2_ub = ', a2_ub
 c 
 c      If particle falls outside of age table, exit
 c 

--- a/src/enzo/tabular_feedback.F
+++ b/src/enzo/tabular_feedback.F
@@ -796,10 +796,10 @@ c     Metallicity indices are not regular but are few in number (~8)
      &          .and. z_ub .lt. ntab_metal)
          z_ub = z_ub + 1_IKIND
       enddo
-c     Ages are many but are regularly spaced in log space so the
+c     Ages are many but are regularly spaced in *log* space so the
 c     indicies can be found algebraically.
 c     First index is zero so our line equation starts at index 2.
-c     The expression return the lower bound so we add 1 to find
+c     The expression returns the lower bound so we add 1 to find
 c     the upper bound. This way I don't have to rewrite any of
 c     the following logic. 
       age_start_log = log10(tab_age(2))
@@ -960,6 +960,7 @@ c      Locals
 c 
       INTG_PREC z_ub, a1_ub, a2_ub ! table index right bounds (for interp)
       R_PREC age1, age2            ! time integration bounds
+      R_PREC age_start, dage       ! for finding age indices
       R_PREC rate1, rate2, t1, t2 
 c 
 c      Set time integration bounds
@@ -968,34 +969,33 @@ c
       if (age .lt. 0) age1 = 0
       age2 = age1 + dt
 c 
-c      Yield table will need to be interpolated in age & metal frac.
-c      Find index to the right (above) of the target values
-c     TODO change to algebra because its faster
+c     Set yield to 0 in case we exit
+c 
+      yield = 0
+c 
+c     Yield table will need to be interpolated in age & metal frac.
+c     Find index to the right (above) of the target value
+c     Metallicity indices are not regular but are few in number (~8)
       z_ub = 1_IKIND
       do while (tab_metal(z_ub) .lt. metal 
      &          .and. z_ub .lt. ntab_metal)
          z_ub = z_ub + 1_IKIND
       enddo
-      a1_ub = 1_IKIND
-      do while (tab_age(a1_ub) .lt. age1 
-     &                  .and. a1_ub .lt. ntab_age)
-         a1_ub = a1_ub + 1_IKIND
-      enddo
-      a2_ub = 1_IKIND
-      do while (tab_age(a2_ub) .lt. age2
-     &            .and. a2_ub .lt. ntab_age)
-         a2_ub = a2_ub + 1_IKIND
-      enddo
+c     Ages are many but are regularly spaced in *linear* space so the
+c     indicies can be found algebraically.
+c     The expression return the lower bound so we add 1 to find
+c     the upper bound. This way I don't have to rewrite any of
+c     the following logic. 
+      age_start = tab_age(1)
+      dage = tab_age(2) - tab_age(1)
+      a1_ub = int((age1-age_start)/dage + 1, IKIND)+1
+      a2_ub = int((age2-age_start)/dage + 1, IKIND)+1
 c 
 c      If particle falls outside of age table, exit
 c 
       if (a1_ub .eq. ntab_age+1) then
          goto 5
       endif
-c 
-c      Otherwise, find yield
-c 
-      yield = 0
 c 
 c      Case 1: both age (age1) & age+dt (age2) are in the same table "cell"
 c 

--- a/src/enzo/tabular_feedback.F
+++ b/src/enzo/tabular_feedback.F
@@ -793,23 +793,22 @@ c     Metallicity indices are not regular but are few in number (~8)
          z_ub = z_ub + 1_IKIND
       enddo
 c     Ages are many but are regularly spaced in log space.
-c     Indicies can be found algebraically. The min and max 
-c     expressions return the lower bound so we add 1 to find
+c     Indicies can be found algebraically. The max 
+c     expression return the lower bound so we add 1 to find
 c     the upper bound. This way I don't have to rewrite any of
 c     the following logic. 
       tab_age_start_log = log10(tab_age(1))
       dtab_age_log = log10(tab_age(2)) - tab_age_start_log
-      a1_ub = min(ntab_age-1,
-     &  max(1, int((log10(age1)-tab_age_start_log)/dtab_age_log, IKIND)+1))+1
-      a2_ub = min(ntab_age-1,
-     &  max(1, int((log10(age2)-tab_age_start_log)/dtab_age_log, IKIND)+1))+1
+      a1_ub = max( 1,
+     & int((log10(age1)-tab_age_start_log)/dtab_age_log, IKIND)+1 )+1
+      a2_ub = max( 1,
+     & int((log10(age2)-tab_age_start_log)/dtab_age_log, IKIND)+1 )+1
 c 
 c      If particle falls outside of age table, exit
 c 
-      if (a1_ub .eq. ntab_age+1) then
+      if (a1_ub .gt. ntab_age) then
          goto 5
       endif
-c ###### END EDIT ######
 c 
 c      Otherwise, find yield
 c 

--- a/src/enzo/tabular_feedback.F
+++ b/src/enzo/tabular_feedback.F
@@ -775,6 +775,7 @@ c      Locals
 c 
       INTG_PREC z_ub, a1_ub, a2_ub ! table index right bounds (for interp)
       R_PREC age1, age2            ! time integration bounds
+      R_PREC tab_age_start_log, dtab_age_log  ! for finding age indices
       R_PREC rate1, rate2, t1, t2 
 c 
 c      Set time integration bounds
@@ -783,30 +784,32 @@ c
       if (age .lt. 0) age1 = 0
       age2 = age1 + dt
 c 
-c      Yield table will need to be interpolated in age & metal frac.
-c      Find index to the right (above) of the target values
-c 
+c     Yield table will need to be interpolated in age & metal frac.
+c     Find index to the right (above) of the target value
+c     Metallicity indices are not regular but are few in number (~8)
       z_ub = 1_IKIND
       do while (tab_metal(z_ub) .lt. metal 
      &          .and. z_ub .lt. ntab_metal)
          z_ub = z_ub + 1_IKIND
       enddo
-      a1_ub = 1_IKIND
-      do while (tab_age(a1_ub) .lt. age1 
-     &                  .and. a1_ub .lt. ntab_age)
-         a1_ub = a1_ub + 1_IKIND
-      enddo
-      a2_ub = 1_IKIND
-      do while (tab_age(a2_ub) .lt. age2
-     &            .and. a2_ub .lt. ntab_age)
-         a2_ub = a2_ub + 1_IKIND
-      enddo
+c     Ages are many but are regularly spaced in log space.
+c     Indicies can be found algebraically. The min and max 
+c     expressions return the lower bound so we add 1 to find
+c     the upper bound. This way I don't have to rewrite any of
+c     the following logic. 
+      tab_age_start_log = log10(tab_age(1))
+      dtab_age_log = log10(tab_age(2)) - tab_age_start_log
+      a1_ub = min(ntab_age-1,
+     &  max(1, int((log10(age1)-tab_age_start_log)/dtab_age_log, IKIND)+1))+1
+      a2_ub = min(ntab_age-1,
+     &  max(1, int((log10(age2)-tab_age_start_log)/dtab_age_log, IKIND)+1))+1
 c 
 c      If particle falls outside of age table, exit
 c 
       if (a1_ub .eq. ntab_age+1) then
          goto 5
       endif
+c ###### END EDIT ######
 c 
 c      Otherwise, find yield
 c 
@@ -965,7 +968,7 @@ c
 c 
 c      Yield table will need to be interpolated in age & metal frac.
 c      Find index to the right (above) of the target values
-c 
+c     TODO change to algebra because its faster
       z_ub = 1_IKIND
       do while (tab_metal(z_ub) .lt. metal 
      &          .and. z_ub .lt. ntab_metal)

--- a/src/enzo/tabular_feedback.F
+++ b/src/enzo/tabular_feedback.F
@@ -778,11 +778,15 @@ c
       R_PREC age_start_log, dage_log  ! for finding age indices
       R_PREC rate1, rate2, t1, t2 
 c 
-c      Set time integration bounds
+c     Set time integration bounds
 c 
       age1 = age
       if (age .lt. 0) age1 = 0
       age2 = age1 + dt
+c
+c     Set yield to 0 in case we exit
+c
+      yield = 0
 c 
 c     Yield table will need to be interpolated in age & metal frac.
 c     Find index to the right (above) of the target value
@@ -812,10 +816,7 @@ c
          goto 5
       endif
 c 
-c      Otherwise, find yield
-c 
-      yield = 0
-c 
+c      Otherwise, find yield.
 c      Case 1: both age (age1) & age+dt (age2) are in the same table "cell"
 c 
       if (a2_ub - a1_ub .eq. 0) then

--- a/src/enzo/tabular_feedback.F
+++ b/src/enzo/tabular_feedback.F
@@ -798,11 +798,13 @@ c     expression return the lower bound so we add 1 to find
 c     the upper bound. This way I don't have to rewrite any of
 c     the following logic. 
       dtab_age_log = log10(tab_age(3)) - log10(tab_age(2))
-      a1_ub = max( 1,
-     & int((log10(age1))/dtab_age_log, IKIND)+1 )+1
-      a2_ub = max( 1,
-     & int((log10(age2))/dtab_age_log, IKIND)+1 )+1
-      write(*,*) '    a1_ub = ', a1_ub, 'a2_ub = ', a2_ub
+      a1_ub = int((log10(age1))/dtab_age_log, IKIND)+1
+      a2_ub = int((log10(age2))/dtab_age_log, IKIND)+1
+c     Correct for log10(0)=-inf case
+      if (age1 .le. 0) a1_ub = 1_IKIND
+      if (age2 .le. 0) a2_ub = 1_IKIND
+      write(*,*) '    dtab_age_log, age1, age2:', dtab_age_log, age1, age2
+      write(*,*) '    a1_ub, a2_ub:', a1_ub, a2_ub
 c 
 c      If particle falls outside of age table, exit
 c 


### PR DESCRIPTION
The tabular feedback table lookup has been refactored to calculate the age indices, since these are uniformly spaced for both the SN and pre-SN tables (the former being logarithmic and the latter linear). I've confirmed the SN indices get calculated correctly but not the pSN indices. I also haven't measured the speedup.

@clochhaas if you could verify some of your test simulations are unchanged and faster that would be great!