### PR TITLE
Feedback injection zone and star ball test

### DIFF
--- a/doc/manual/source/parameters/index.rst
+++ b/doc/manual/source/parameters/index.rst
@@ -2206,17 +2206,27 @@ General Star Formation
     deposited into the host cell and neighboring cells within this
     radius.  This results in feedback being distributed to a cube with
     a side of ``StarFeedbackDistRadius+1``. It is in units of cell
-    widths of the finest grid which hosts the star particle.  Only
-    implemented for ``StarParticleCreation`` method = 0 or 1 with ``StarParticleFeedback`` method =  1. (If ``StarParticleFeedback`` = 0, stellar feedback is only deposited into the cell in which the star particle lives).  Default: 0.
+    widths of the finest grid which hosts the star particle.  Implemented
+    for ``StarParticleCreation`` method = 0 or 1 with ``StarParticleFeedback``
+    method = 1, and for ``StarParticleFeedback`` method = 64 (Kimm & Cen
+    momentum feedback). (If ``StarParticleFeedback`` = 0, stellar feedback
+    is only deposited into the cell in which the star particle lives).
+    For method = 64, a value of 0 defaults to a 3x3x3 injection cube
+    (equivalent to ``StarFeedbackDistRadius = 1``).  Default: 0.
 
 ``StarFeedbackDistCellStep`` (external)
     In essence, this parameter controls the shape of the volume where
-    the feedback is applied, cropping the original cube.  This volume
-    that are within ``StarFeedbackDistCellSteps`` cells from the host
+    the feedback is applied, cropping the original cube.  Only cells
+    that are within ``StarFeedbackDistCellStep`` steps from the host
     cell, counted in steps in Cartesian directions, are injected with
     stellar feedback.  Its maximum value is ``StarFeedbackDistRadius``
-    * ``TopGridRank``.  Only implemented for ``StarParticleCreation`` method = 0
-    or 1  with ``StarParticleFeedback`` method =  1.  See :ref:`distributed_feedback` for an illustration.
+    * ``TopGridRank``.  Implemented for ``StarParticleCreation`` method = 0
+    or 1 with ``StarParticleFeedback`` method = 1, and for
+    ``StarParticleFeedback`` method = 64 (Kimm & Cen momentum feedback).
+    For method = 64, a value of 0 defaults to a maximum step of 3
+    (equivalent to ``StarFeedbackDistCellStep = 3``), which together with
+    the default ``StarFeedbackDistRadius`` includes all 27 cells of a
+    3x3x3 cube.  See :ref:`distributed_feedback` for an illustration.
     Default: 0.
 
 ``StarMakerUseJeansMass`` (external)

--- a/doc/manual/source/parameters/index.rst
+++ b/doc/manual/source/parameters/index.rst
@@ -2734,7 +2734,7 @@ The parameters below are currently considered in ``StarFeedback`` method 6.
 See :ref:`method_6`.
 
 ``StarFeedbackMomentumMultiplier`` (external)
-    This parameter is used to multiply the strength of the injected momentum. Default value is 1.0.
+    This parameter is used to multiply the strength of the injected momentum. If set to 0.0, thermal energy will instead be injected at a rate of 1e51 ergs per supernova. Default value is 1.0.
 ``StarFeedbackSNePerTimestepLimit`` (external)
     This parameter is used to limit how many supernovae must occur per cell per time step in order for feedback to be injected. Default value is 1e-3.
 ``StarFeedbackStochasticSNe`` (external)

--- a/doc/manual/source/parameters/index.rst
+++ b/doc/manual/source/parameters/index.rst
@@ -2223,9 +2223,10 @@ General Star Formation
     * ``TopGridRank``.  Implemented for ``StarParticleCreation`` method = 0
     or 1 with ``StarParticleFeedback`` method = 1, and for
     ``StarParticleFeedback`` method = 64 (Kimm & Cen momentum feedback).
-    For method = 64, a value of 0 defaults to a maximum step of 3
-    (equivalent to ``StarFeedbackDistCellStep = 3``), which together with
-    the default ``StarFeedbackDistRadius`` includes all 27 cells of a
+    For method = 64, any value less than StarFeedbackDistRadius
+    defaults ``StarFeedbackDistCellStep = StarFeedbackDistRadius``, except for
+    a value of 0, which defaults to a value of 3 instead. Together with
+    the default value of ``StarFeedbackDistRadius``, this includes all 27 cells of a
     3x3x3 cube.  See :ref:`distributed_feedback` for an illustration.
     Default: 0.
 

--- a/doc/manual/source/physics/star_particles.rst
+++ b/doc/manual/source/physics/star_particles.rst
@@ -345,18 +345,20 @@ number of supernovae per particle in each timestep cannot be between zero and on
 If ``StarFeedbackSNePerTimestepLimit`` is greater than one, it will limit 
 the stochastic supernovae case in the same way.
 
-For each grid cell in which supernovae are occuring ("explosion cell"), the total momentum that 
-will be injected into the 27 cells in a 3x3x3 cube surrounding the cell 
-depends on whether or not the Sedov blast wave for the explosion would 
-be resolved, which is determined by comparing the ejected mass to the swept-up 
-mass in each cell surrounding the explosion cell. 
+For each grid cell in which supernovae are occuring ("explosion cell"), the total momentum that
+will be injected into the cells surrounding the explosion cell
+depends on whether or not the Sedov blast wave for the explosion would
+be resolved, which is determined by comparing the ejected mass to the swept-up
+mass in each cell surrounding the explosion cell.
 
-The ejected mass per cell is given by dM\ :sub:`ej` = M\ :sub:`ej`/N\ :sub:`cells`, 
-where M\ :sub:`ej` is the total ejected mass at this time step from all particles 
-in the explosion cell and N\ :sub:`cells` 
-is the number of cells among which the feedback is distributed. Currently, 
-N\ :sub:`cells` = 27 and allowing different values using the parameters 
-``StarFeedbackDistRadius`` and ``StarFeebackDistCellStep`` is NOT implemented.
+The injection region is controlled by ``StarFeedbackDistRadius`` and
+``StarFeedbackDistCellStep``; see :ref:`distributed_feedback` for details.
+By default, both parameters are unset (value 0), which causes this method to
+fall back to a 3x3x3 cube (N\ :sub:`cells` = 27).
+
+The ejected mass per cell is given by dM\ :sub:`ej` = M\ :sub:`ej`/N\ :sub:`cells`,
+where M\ :sub:`ej` is the total ejected mass at this time step from all particles
+in the explosion cell and N\ :sub:`cells` is the number of cells in the injection region.
 
 For each cell surrounding the explosion cell, the swept-up 
 mass is given by:

--- a/run/StarParticle/StarParticleMultiTest/TestStarParticleMulti.enzo
+++ b/run/StarParticle/StarParticleMultiTest/TestStarParticleMulti.enzo
@@ -1,0 +1,81 @@
+#
+# AMR PROBLEM DEFINITION FILE: TestMultiStarParticle
+#
+#  define problem
+#
+ProblemType                = 92        // TestMultiStarParticle
+TopGridRank                = 3
+TopGridDimensions          = 64 64 64
+#
+#  Units
+#
+LengthUnits                = 1.2344e+21   // 400 pc
+TimeUnits                  = 3.15e13      // 10 Myr
+DensityUnits               = 1.0e-24      // ~1 part/cc
+#
+#  test problem parameters
+#
+TestMultiStarParticleDensity              = 1.0
+TestMultiStarParticleEnergy               = 6.55410093179e-06
+TestProblemInitialMetallicityFraction     = 2e-3   // ~0.1 Zsun
+#
+#  multi-star sphere parameters
+#
+TestMultiStarParticleNParticles           = 50     // minimum number of star particles;
+                                                   // actual count rounds up to complete
+                                                   // the last shell
+TestMultiStarParticleSphereRadius         = 0.15   // sphere radius in code units;
+                                                   // inter-particle spacing derived as
+                                                   // SphereRadius / n_shells
+TestMultiStarParticleCenter               = 0.5 0.5 0.5
+TestMultiStarParticleStarMass             = 100.0  // solar masses, same for all particles
+TestMultiStarParticleStarVelocity         = 0.0 0.0 0.0  // km/s, same for all particles
+TestMultiStarParticleStarMetallicityFraction = 0.0
+#
+#  star particle / feedback parameters
+#
+StarParticleFeedback            = 16384   // kinetic feedback (method 14)
+StarEnergyToThermalFeedback     = 5.59e-6
+StarMassEjectionFraction        = 0.25
+StarFeedbackKineticFraction     = 0.3
+StarMakerExplosionDelayTime     = 0.0
+#
+#  set I/O and stop/start parameters
+#
+StopTime                   = 1
+dtDataDump                 = 0.1
+Initialdt                  = 0.0010017410642
+OutputTemperature          = 1
+OutputCoolingTime          = 1
+#
+#  set Hydro parameters
+#
+HydroMethod                = 0
+DualEnergyFormalism        = 1
+CourantSafetyNumber        = 0.4
+PPMDiffusionParameter      = 0       // diffusion off
+PPMFlatteningParameter     = 0       // flattening on
+PPMSteepeningParameter     = 0       // steepening on
+Gamma                      = 1.6666667
+#
+#  set grid refinement parameters
+#
+StaticHierarchy            = 1       // static hierarchy
+RefineBy                   = 2
+MaximumRefinementLevel     = 0
+CellFlaggingMethod         = 0
+#
+#  Cooling
+#
+RadiativeCooling           = 0
+#MultiSpecies              = 1
+#MetalCooling              = 3
+#CloudyCoolingGridFile     = solar_2008_3D_metals.h5
+#TestProblemMultiSpecies   = 1
+#TestProblemUseMetallicityField        = 1
+#TestProblemHydrogenFractionByMass     = 0.75
+#TestProblemInitialMetallicityFraction = 2e-3
+#TestProblemInitialHIFraction          = 0.998
+#TestProblemInitialHeIFraction         = 1.0
+#TestProblemInitialHeIIFraction        = 1.0e-20
+#TestProblemInitialHeIIIIFraction      = 1.0e-20

--- a/src/enzo/Grid.h
+++ b/src/enzo/Grid.h
@@ -2130,11 +2130,20 @@ int zEulerSweep(int j, int NumberOfSubgrids, fluxes *SubgridFluxes[],
                  float TestStarParticleMetallicity);
 
 /* Double Star Particle test: initialize particle */
-  int TestDoubleStarParticleInitializeGrid(FLOAT TestStarParticleStarMass[2], 
+  int TestDoubleStarParticleInitializeGrid(FLOAT TestStarParticleStarMass[2],
 				     float *Initialdt,
 				     FLOAT TestStarParticleStarVelocity[2][3],
 				     FLOAT TestStarParticleStarPosition[2][3],
                  FLOAT TestStarParticleMetallicity[2]);
+
+/* Multi-Star Particle test: initialize particles on a sphere */
+  int TestMultiStarParticleInitializeGrid(int NParticles,
+                                          FLOAT SphereRadius,
+                                          FLOAT Center[],
+                                          float StarMass,
+                                          FLOAT StarVelocity[],
+                                          float StarMetallicity,
+                                          float *Initialdt);
 
 /* Gravity Test: initialize grid. */
 

--- a/src/enzo/Grid.h
+++ b/src/enzo/Grid.h
@@ -2143,6 +2143,11 @@ int zEulerSweep(int j, int NumberOfSubgrids, fluxes *SubgridFluxes[],
                                           float StarMass,
                                           FLOAT StarVelocity[],
                                           float StarMetallicity,
+                                          int UseSphProfile,
+                                          FLOAT SphProfileRadius,
+                                          float SphProfileAlpha,
+                                          float InnerDensity,
+                                          float InnerEnergy,
                                           float *Initialdt);
 
 /* Gravity Test: initialize grid. */

--- a/src/enzo/Grid_StarParticleHandler.C
+++ b/src/enzo/Grid_StarParticleHandler.C
@@ -371,6 +371,7 @@ extern "C" void FORTRAN_NAME(star_feedback6)(int *nx, int *ny, int *nz,
 		       float *dt, float *dx, FLOAT *t, float *z, int *procnum,
              float *d1, float *x1, float *v1, float *t1,
              float *m_eject, float *yield,
+             int *distrad, int *diststep, int *distcells,
              int *nmax, FLOAT *xstart, FLOAT *ystart, FLOAT *zstart,
 		       int *ibuff,
              FLOAT *xp, FLOAT *yp, FLOAT *zp, float *up, float *vp, float *wp,
@@ -378,9 +379,9 @@ extern "C" void FORTRAN_NAME(star_feedback6)(int *nx, int *ny, int *nz,
 	          float *nsn_timestep, float *exptime, float *mom_mult, int *kick_cap,
              int *feedback_log, int *use_tabfbk, float *minit,
              float *ergSNII, float *ergSNIa, int *itracksrc, float *metalSNII,
-             float *metalSNIa, int *ntabZ, int *ntabAge, double *tabZ, double *tabAge, 
+             float *metalSNIa, int *ntabZ, int *ntabAge, double *tabZ, double *tabAge,
              double *tabMass, double *tabMetal, double *tabEvents, int *stochastic,
-             int *preSN, int *preSNmom, int *pSNntabZ, int *pSNntabAge, double *pSNtabZ, 
+             int *preSN, int *preSNmom, int *pSNntabZ, int *pSNntabAge, double *pSNtabZ,
              double *pSNtabAge, double *pSNtabMass, double *pSNtabMetal, double *pSNtabMom);
 
 extern "C" void FORTRAN_NAME(star_feedback3)(int *nx, int *ny, int *nz,
@@ -1830,6 +1831,18 @@ int grid::StarParticleHandler(HierarchyEntry* SubgridPointer, int level,
       }
     }
     
+    // Resolve feedback injection region parameters. Default (value 0) falls
+    // back to a 3x3x3 cube (distrad=1, diststep=3). Compute distcells here
+    // since ReadParameterFile only calculates StarFeedbackDistTotalCells for
+    // NORMAL_STAR/UNIGRID_STAR methods, not MECH_STAR.
+    int distRadEff  = (StarFeedbackDistRadius  > 0) ? StarFeedbackDistRadius  : 1;
+    int distStepEff = (StarFeedbackDistCellStep > 0) ? StarFeedbackDistCellStep : 3;
+    int distCellsEff = 0;
+    for (int dk = -distRadEff; dk <= distRadEff; dk++)
+      for (int dj = -distRadEff; dj <= distRadEff; dj++)
+        for (int di = -distRadEff; di <= distRadEff; di++)
+          if (ABS(dk) + ABS(dj) + ABS(di) <= distStepEff) distCellsEff++;
+
     FORTRAN_NAME(star_feedback6)(
        GridDimension, GridDimension+1, GridDimension+2,
        BaryonField[DensNum], mu_field,
@@ -1840,7 +1853,8 @@ int grid::StarParticleHandler(HierarchyEntry* SubgridPointer, int level,
           &Time, &zred, &MyProcessorNumber,
        &DensityUnits, &LengthUnits, &VelocityUnits, &TimeUnits,
           &StarMassEjectionFraction,
-          &StarMetalYield, 
+          &StarMetalYield,
+       &distRadEff, &distStepEff, &distCellsEff,
        &NumberOfParticles,
           CellLeftEdge[0], CellLeftEdge[1], CellLeftEdge[2], &GhostZones,
        ParticlePosition[0], ParticlePosition[1],

--- a/src/enzo/Grid_StarParticleHandler.C
+++ b/src/enzo/Grid_StarParticleHandler.C
@@ -1831,18 +1831,6 @@ int grid::StarParticleHandler(HierarchyEntry* SubgridPointer, int level,
       }
     }
     
-    // Resolve feedback injection region parameters. Default (value 0) falls
-    // back to a 3x3x3 cube (distrad=1, diststep=3). Compute distcells here
-    // since ReadParameterFile only calculates StarFeedbackDistTotalCells for
-    // NORMAL_STAR/UNIGRID_STAR methods, not MECH_STAR.
-    int distRadEff  = (StarFeedbackDistRadius  > 0) ? StarFeedbackDistRadius  : 1;
-    int distStepEff = (StarFeedbackDistCellStep > 0) ? StarFeedbackDistCellStep : 3;
-    int distCellsEff = 0;
-    for (int dk = -distRadEff; dk <= distRadEff; dk++)
-      for (int dj = -distRadEff; dj <= distRadEff; dj++)
-        for (int di = -distRadEff; di <= distRadEff; di++)
-          if (ABS(dk) + ABS(dj) + ABS(di) <= distStepEff) distCellsEff++;
-
     FORTRAN_NAME(star_feedback6)(
        GridDimension, GridDimension+1, GridDimension+2,
        BaryonField[DensNum], mu_field,
@@ -1854,7 +1842,7 @@ int grid::StarParticleHandler(HierarchyEntry* SubgridPointer, int level,
        &DensityUnits, &LengthUnits, &VelocityUnits, &TimeUnits,
           &StarMassEjectionFraction,
           &StarMetalYield,
-       &distRadEff, &distStepEff, &distCellsEff,
+       &StarFeedbackDistRadius, &StarFeedbackDistCellStep, &StarFeedbackDistTotalCells,
        &NumberOfParticles,
           CellLeftEdge[0], CellLeftEdge[1], CellLeftEdge[2], &GhostZones,
        ParticlePosition[0], ParticlePosition[1],

--- a/src/enzo/Grid_TestMultiStarParticleInitializeGrid.C
+++ b/src/enzo/Grid_TestMultiStarParticleInitializeGrid.C
@@ -24,6 +24,14 @@
 /      Spacing = SphereRadius / n_shells
 /    The actual particle count and derived spacing are printed at runtime.
 /
+/    If UseSphProfile is set, the gas density and temperature outside
+/    SphProfileRadius follow a power-law profile:
+/      rho(r) = InnerDensity * (SphProfileRadius / r)^SphProfileAlpha
+/    with the internal energy adjusted to maintain constant pressure:
+/      epsilon(r) = InnerEnergy * (r / SphProfileRadius)^SphProfileAlpha
+/    Inside SphProfileRadius the fields are left at the uniform values
+/    set by InitializeUniformGrid.
+/
 /  RETURNS: FAIL or SUCCESS
 /
 ************************************************************************/
@@ -51,6 +59,11 @@ int grid::TestMultiStarParticleInitializeGrid(int NParticles,
                                               float StarMass,
                                               FLOAT StarVelocity[],
                                               float StarMetallicity,
+                                              int UseSphProfile,
+                                              FLOAT SphProfileRadius,
+                                              float SphProfileAlpha,
+                                              float InnerDensity,
+                                              float InnerEnergy,
                                               float *Initialdt)
 {
   int i, j, dim;
@@ -187,6 +200,46 @@ int grid::TestMultiStarParticleInitializeGrid(int NParticles,
   }
 
   delete[] N_per_shell;
+
+  /* Apply spherical atmosphere profile outside SphProfileRadius. */
+
+  if (UseSphProfile) {
+
+    int DensNum, GENum, Vel1Num, Vel2Num, Vel3Num, TENum;
+    IdentifyPhysicalQuantities(DensNum, GENum, Vel1Num, Vel2Num, Vel3Num, TENum);
+
+    int k_idx, j_idx, i_idx, index;
+    float delx, dely, delz, r, ratio;
+
+    for (k_idx = GridStartIndex[2]; k_idx <= GridEndIndex[2]; k_idx++) {
+      delz = (GridRank > 2) ?
+        (float)(CellLeftEdge[2][k_idx] + 0.5*CellWidth[2][k_idx] - Center[2]) : 0.0;
+      for (j_idx = GridStartIndex[1]; j_idx <= GridEndIndex[1]; j_idx++) {
+        dely = (GridRank > 1) ?
+          (float)(CellLeftEdge[1][j_idx] + 0.5*CellWidth[1][j_idx] - Center[1]) : 0.0;
+        for (i_idx = GridStartIndex[0]; i_idx <= GridEndIndex[0]; i_idx++) {
+          delx = (float)(CellLeftEdge[0][i_idx] + 0.5*CellWidth[0][i_idx] - Center[0]);
+          r = sqrt(delx*delx + dely*dely + delz*delz);
+
+          index = (k_idx * GridDimension[1] + j_idx) * GridDimension[0] + i_idx;
+          if (r > (float)SphProfileRadius) {
+            ratio = r / (float)SphProfileRadius;
+            float density   = InnerDensity * pow(ratio, -SphProfileAlpha);
+            float internalE = InnerEnergy  * pow(ratio,  SphProfileAlpha);
+            float vx = BaryonField[Vel1Num][index];
+            float vy = (GridRank > 1) ? BaryonField[Vel2Num][index] : 0.0f;
+            float vz = (GridRank > 2) ? BaryonField[Vel3Num][index] : 0.0f;
+            float totalE = internalE + 0.5f * (vx*vx + vy*vy + vz*vz);
+
+            BaryonField[DensNum][index] = density;
+            BaryonField[TENum][index]   = totalE;
+            if (DualEnergyFormalism)
+              BaryonField[GENum][index] = internalE;
+          }
+        }
+      }
+    }
+  }
 
   return SUCCESS;
 }

--- a/src/enzo/Grid_TestMultiStarParticleInitializeGrid.C
+++ b/src/enzo/Grid_TestMultiStarParticleInitializeGrid.C
@@ -1,0 +1,192 @@
+/***********************************************************************
+/
+/  GRID CLASS (INITIALIZE THE GRID FOR A MULTI-STAR PARTICLE TEST)
+/
+/  written by: Cassi Lochhaas
+/  date:       2026
+/  modified1:
+/
+/  PURPOSE:
+/    Places star particles distributed uniformly throughout a sphere
+/    centered at Center[], using concentric Fibonacci shells.
+/
+/    Shells are placed at r = Spacing, 2*Spacing, 3*Spacing, ..., with
+/    each shell independently populated using the Fibonacci spiral for
+/    near-uniform surface coverage.  The number of particles on shell k
+/    is max(1, round(4*pi*k^2)), matching the shell's surface area, so
+/    the inter-particle spacing is Spacing throughout the volume.
+/    One particle is placed at the center (k=0).
+/
+/    NParticles sets the minimum number of particles: shells are added
+/    until the total meets or exceeds NParticles, with the last shell
+/    always completed to preserve the uniform spacing.  Spacing is
+/    derived from the user-supplied SphereRadius:
+/      Spacing = SphereRadius / n_shells
+/    The actual particle count and derived spacing are printed at runtime.
+/
+/  RETURNS: FAIL or SUCCESS
+/
+************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "ErrorExceptions.h"
+#include "macros_and_parameters.h"
+#include "typedefs.h"
+#include "global_data.h"
+#include "Fluxes.h"
+#include "GridList.h"
+#include "ExternalBoundary.h"
+#include "Grid.h"
+#include "phys_constants.h"
+
+int GetUnits(float *DensityUnits, float *LengthUnits,
+             float *TemperatureUnits, float *TimeUnits,
+             float *VelocityUnits, double *MassUnits, FLOAT Time);
+
+int grid::TestMultiStarParticleInitializeGrid(int NParticles,
+                                              FLOAT SphereRadius,
+                                              FLOAT Center[],
+                                              float StarMass,
+                                              FLOAT StarVelocity[],
+                                              float StarMetallicity,
+                                              float *Initialdt)
+{
+  int i, j, dim;
+
+  /* Return if this doesn't concern us. */
+
+  if (ProcessorNumber != MyProcessorNumber)
+    return SUCCESS;
+
+  /* Get Units. */
+
+  float TemperatureUnits = 1, DensityUnits = 1, LengthUnits = 1,
+    VelocityUnits = 1, TimeUnits = 1;
+  double MassUnits = 1;
+
+  if (GetUnits(&DensityUnits, &LengthUnits, &TemperatureUnits,
+               &TimeUnits, &VelocityUnits, &MassUnits, Time) == FAIL) {
+    ENZO_FAIL("Error in GetUnits.\n");
+  }
+
+  /* Convert star mass to simulation units (mass per cell volume). */
+
+  float ParticleMassCode = StarMass * SolarMass * POW(LengthUnits * CellWidth[0][0], -3.0) / DensityUnits;
+
+  printf("Multi-star particle mass (code units): %f\n", ParticleMassCode);
+
+  /* Add shells using natural filling (N_k = round(4*pi*k^2)) until the
+     running total meets or exceeds NParticles.  The last shell is always
+     completed so every shell has uniform surface coverage.
+     Spacing is derived from SphereRadius once n_shells is known. */
+
+  int n_shells = 0;
+  int actual_N = 1;  /* center particle */
+  while (actual_N < NParticles) {
+    n_shells++;
+    int N_k = (int)(4.0 * M_PI * n_shells * n_shells + 0.5);
+    if (N_k < 1) N_k = 1;
+    actual_N += N_k;
+  }
+
+  FLOAT Spacing = (n_shells > 0) ? SphereRadius / n_shells : SphereRadius;
+
+  if (actual_N != NParticles)
+    printf("TestMultiStarParticle: requested %d particles; "
+           "placing %d to complete last shell\n", NParticles, actual_N);
+
+  /* Build per-shell counts */
+  int *N_per_shell = new int[n_shells];
+  for (i = 0; i < n_shells; i++) {
+    int k = i + 1;
+    N_per_shell[i] = (int)(4.0 * M_PI * k * k + 0.5);
+    if (N_per_shell[i] < 1) N_per_shell[i] = 1;
+  }
+
+  /* Set number of particles and allocate. */
+
+  NumberOfParticles = actual_N;
+  NumberOfParticleAttributes = 4;
+  this->AllocateNewParticles(NumberOfParticles);
+  printf("Allocated %d particles on %d shells\n", NumberOfParticles, n_shells);
+  printf("Multi-star sphere radius (code units): %"PSYM"\n", SphereRadius);
+  printf("Multi-star inter-particle spacing (code units): %"PSYM"\n", Spacing);
+
+  /* Set particle IDs and types */
+
+  for (i = 0; i < NumberOfParticles; i++) {
+    ParticleNumber[i] = i;
+    ParticleType[i] = PARTICLE_TYPE_STAR;
+  }
+
+  /* Place particles on concentric Fibonacci shells.
+     Shell k (k >= 1) is at radius r = k * Spacing and receives N_per_shell[k-1]
+     particles placed with the Fibonacci spiral, covering the full sphere surface.
+     One particle is placed at the center (k=0). */
+
+  const double golden_ratio = (1.0 + sqrt(5.0)) / 2.0;
+  int count = 0;
+
+  /* Center particle */
+  if (GridRank > 0) ParticlePosition[0][count] = Center[0];
+  if (GridRank > 1) ParticlePosition[1][count] = Center[1];
+  if (GridRank > 2) ParticlePosition[2][count] = Center[2];
+  for (dim = 0; dim < GridRank; dim++)
+    ParticleVelocity[dim][count] = StarVelocity[dim] * 1e5 * TimeUnits / LengthUnits;
+  ParticleMass[count] = ParticleMassCode;
+  if (StarMakerStoreInitialMass)
+    ParticleInitialMass[count] = ParticleMassCode;
+  ParticleAttribute[0][count] = Time + 1e-7;
+  ParticleAttribute[1][count] = StarMakerMinimumDynamicalTime * yr_s / TimeUnits;
+  if (STARFEED_METHOD(UNIGRID_STAR)) ParticleAttribute[1][count] = 10.0 * Myr_s / TimeUnits;
+  if (STARFEED_METHOD(MOM_STAR) || STARFEED_METHOD(MECH_STAR))
+    if (StarMakerExplosionDelayTime >= 0.0)
+      ParticleAttribute[1][count] = 1.0;
+  ParticleAttribute[2][count] = StarMetallicity;
+  ParticleAttribute[3][count] = 0.0;
+  count++;
+
+  /* Shells */
+  int shell;
+  for (shell = 1; shell <= n_shells; shell++) {
+    double r = shell * (double)Spacing;
+    int N_shell = N_per_shell[shell - 1];
+
+    for (j = 0; j < N_shell; j++) {
+      double phi   = acos(1.0 - 2.0 * (j + 0.5) / (double)N_shell);
+      double theta = 2.0 * M_PI * (double)j / golden_ratio;
+
+      FLOAT dx = r * sin(phi) * cos(theta);
+      FLOAT dy = r * sin(phi) * sin(theta);
+      FLOAT dz = r * cos(phi);
+
+      if (GridRank > 0) ParticlePosition[0][count] = Center[0] + dx;
+      if (GridRank > 1) ParticlePosition[1][count] = Center[1] + dy;
+      if (GridRank > 2) ParticlePosition[2][count] = Center[2] + dz;
+
+      for (dim = 0; dim < GridRank; dim++)
+        ParticleVelocity[dim][count] = StarVelocity[dim] * 1e5 * TimeUnits / LengthUnits;
+
+      ParticleMass[count] = ParticleMassCode;
+      if (StarMakerStoreInitialMass)
+        ParticleInitialMass[count] = ParticleMassCode;
+
+      ParticleAttribute[0][count] = Time + 1e-7;
+      ParticleAttribute[1][count] = StarMakerMinimumDynamicalTime * yr_s / TimeUnits;
+      if (STARFEED_METHOD(UNIGRID_STAR)) ParticleAttribute[1][count] = 10.0 * Myr_s / TimeUnits;
+      if (STARFEED_METHOD(MOM_STAR) || STARFEED_METHOD(MECH_STAR))
+        if (StarMakerExplosionDelayTime >= 0.0)
+          ParticleAttribute[1][count] = 1.0;
+
+      ParticleAttribute[2][count] = StarMetallicity;
+      ParticleAttribute[3][count] = 0.0;
+      count++;
+    }
+  }
+
+  delete[] N_per_shell;
+
+  return SUCCESS;
+}

--- a/src/enzo/Grid_TestMultiStarParticleInitializeGrid.C
+++ b/src/enzo/Grid_TestMultiStarParticleInitializeGrid.C
@@ -99,7 +99,7 @@ int grid::TestMultiStarParticleInitializeGrid(int NParticles,
   int actual_N = 1;  /* center particle */
   while (actual_N < NParticles) {
     n_shells++;
-    int N_k = (int)(4.0 * M_PI * n_shells * n_shells + 0.5);
+    int N_k = (int)(4.0 * pi * n_shells * n_shells + 0.5);
     if (N_k < 1) N_k = 1;
     actual_N += N_k;
   }
@@ -114,7 +114,7 @@ int grid::TestMultiStarParticleInitializeGrid(int NParticles,
   int *N_per_shell = new int[n_shells];
   for (i = 0; i < n_shells; i++) {
     int k = i + 1;
-    N_per_shell[i] = (int)(4.0 * M_PI * k * k + 0.5);
+    N_per_shell[i] = (int)(4.0 * pi * k * k + 0.5);
     if (N_per_shell[i] < 1) N_per_shell[i] = 1;
   }
 
@@ -169,7 +169,7 @@ int grid::TestMultiStarParticleInitializeGrid(int NParticles,
 
     for (j = 0; j < N_shell; j++) {
       double phi   = acos(1.0 - 2.0 * (j + 0.5) / (double)N_shell);
-      double theta = 2.0 * M_PI * (double)j / golden_ratio;
+      double theta = 2.0 * pi * (double)j / golden_ratio;
 
       FLOAT dx = r * sin(phi) * cos(theta);
       FLOAT dy = r * sin(phi) * sin(theta);

--- a/src/enzo/InitializeNew.C
+++ b/src/enzo/InitializeNew.C
@@ -91,6 +91,8 @@ int TestStarParticleInitialize(FILE *fptr, FILE *Outfptr, HierarchyEntry &TopGri
 			       TopGridData &MetaData, float *Initialdt);
 int TestDoubleStarParticleInitialize(FILE *fptr, FILE *Outfptr, HierarchyEntry &TopGrid,
 			       TopGridData &MetaData, float *Initialdt);
+int TestMultiStarParticleInitialize(FILE *fptr, FILE *Outfptr, HierarchyEntry &TopGrid,
+			       TopGridData &MetaData, float *Initialdt);
 int KHInitialize(FILE *fptr, FILE *Outfptr, HierarchyEntry &TopGrid,
                           TopGridData &MetaData);
 int NohInitialize(FILE *fptr, FILE *Outfptr, HierarchyEntry &TopGrid,
@@ -603,7 +605,12 @@ int InitializeNew(char *filename, HierarchyEntry &TopGrid,
   
   // 91) Test double star particle explosion
   if (ProblemType == 91)
-    ret = TestDoubleStarParticleInitialize(fptr, Outfptr, TopGrid, MetaData, 
+    ret = TestDoubleStarParticleInitialize(fptr, Outfptr, TopGrid, MetaData,
+				     Initialdt);
+
+  // 92) Test multi-star particle explosion (spherical formation)
+  if (ProblemType == 92)
+    ret = TestMultiStarParticleInitialize(fptr, Outfptr, TopGrid, MetaData,
 				     Initialdt);
   
   /* 101) 3D Collapse */

--- a/src/enzo/Make.config.objects
+++ b/src/enzo/Make.config.objects
@@ -661,6 +661,7 @@ OBJS_CONFIG_LIB = \
         Grid_TestOrbitInitializeGrid.o \
 	Grid_TestStarParticleInitializeGrid.o \
 	Grid_TestDoubleStarParticleInitializeGrid.o \
+	Grid_TestMultiStarParticleInitializeGrid.o \
         Grid_TracerParticleCreateParticles.o \
         Grid_TracerParticleOutputData.o \
         Grid_TracerParticleSetVelocity.o \
@@ -957,6 +958,7 @@ OBJS_CONFIG_LIB = \
         TestOrbitInitialize.o \
 	TestStarParticleInitialize.o \
 	TestDoubleStarParticleInitialize.o \
+	TestMultiStarParticleInitialize.o \
         TracerParticleCreation.o \
 	TransposeRegionOverlap.o \
         tscint1d.o \

--- a/src/enzo/ReadParameterFile.C
+++ b/src/enzo/ReadParameterFile.C
@@ -1902,6 +1902,39 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     }
   }
 
+  if (STARFEED_METHOD(MECH_STAR)) {
+    if (StarFeedbackDistRadius > 0) {
+
+    // Ensure cell step is not smaller than radius, to avoid eroding feedback region
+    if (StarFeedbackDistCellStep < StarFeedbackDistRadius) {
+      StarFeedbackDistCellStep = StarFeedbackDistRadius;
+    }
+      // Calculate number of cells in the shape over which to distribute feedback.
+    int i, j, k, cell_step;
+
+    StarFeedbackDistTotalCells = 0;
+    for (k = -StarFeedbackDistRadius;k <= StarFeedbackDistRadius;k++) {
+      for (j = -StarFeedbackDistRadius;j <= StarFeedbackDistRadius;j++) {
+	for (i = -StarFeedbackDistRadius;i <= StarFeedbackDistRadius;i++) {
+	  cell_step = ABS(k) + ABS(j) + ABS(i);
+	  if (cell_step <= StarFeedbackDistCellStep) {
+	    StarFeedbackDistTotalCells++;
+	  }
+       }
+      }
+    }
+  }
+  else {  // Default value needs to be 3x3x3 cube for this feedback method
+    StarFeedbackDistRadius = 1;
+    StarFeedbackDistCellStep = 3;
+    StarFeedbackDistTotalCells = 9;
+  }
+    if (MyProcessorNumber == ROOT_PROCESSOR) {
+      fprintf(stderr,"Total cells for star feedback smoothing: %"ISYM".\n",
+	      StarFeedbackDistTotalCells);
+    }
+  }
+
   /* For rk_hydro, we need to set some variables */
 
   if (DualEnergyFormalism) {

--- a/src/enzo/TestMultiStarParticleInitialize.C
+++ b/src/enzo/TestMultiStarParticleInitialize.C
@@ -22,6 +22,16 @@
 /      TestMultiStarParticleStarVelocity  -- velocity for all particles in km/s (default 0 0 0)
 /      TestMultiStarParticleStarMetallicityFraction -- metallicity fraction (default 0)
 /
+/    Spherical atmosphere parameters (all ignored unless UseSphProfile = 1):
+/      TestMultiStarParticleUseSphProfile      -- enable spherical profile (default 0)
+/      TestMultiStarParticleSphProfileRadius   -- transition radius between inner uniform
+/                                                 region and outer power-law profile,
+/                                                 in code units (default 0.3)
+/      TestMultiStarParticleSphProfileAlpha    -- power-law slope for the outer density
+/                                                 profile: rho(r) = rho_0*(r_0/r)^alpha
+/                                                 (default 2.0); temperature adjusts to
+/                                                 maintain constant pressure
+/
 /  RETURNS: SUCCESS or FAIL
 /
 ************************************************************************/
@@ -100,6 +110,10 @@ int TestMultiStarParticleInitialize(FILE *fptr, FILE *Outfptr, HierarchyEntry &T
   FLOAT TestMultiStarParticleStarVelocity[3] = {0.0, 0.0, 0.0};
   float TestMultiStarParticleStarMetallicityFraction = 0.0;
 
+  int   TestMultiStarParticleUseSphProfile    = 0;
+  FLOAT TestMultiStarParticleSphProfileRadius = 0.3;
+  float TestMultiStarParticleSphProfileAlpha  = 2.0;
+
   int TestProblemUseMetallicityField = 1;
   float TestProblemInitialMetallicityFraction = 2e-3; // 0.1 Zsun
 
@@ -137,6 +151,13 @@ int TestMultiStarParticleInitialize(FILE *fptr, FILE *Outfptr, HierarchyEntry &T
                   &TestMultiStarParticleStarVelocity[2]);
     ret += sscanf(line, "TestMultiStarParticleStarMetallicityFraction = %"FSYM,
                   &TestMultiStarParticleStarMetallicityFraction);
+
+    ret += sscanf(line, "TestMultiStarParticleUseSphProfile = %"ISYM,
+                  &TestMultiStarParticleUseSphProfile);
+    ret += sscanf(line, "TestMultiStarParticleSphProfileRadius = %"PSYM,
+                  &TestMultiStarParticleSphProfileRadius);
+    ret += sscanf(line, "TestMultiStarParticleSphProfileAlpha = %"FSYM,
+                  &TestMultiStarParticleSphProfileAlpha);
 
     ret += sscanf(line, "TestProblemUseMetallicityField  = %"ISYM, &TestProblemData.UseMetallicityField);
     ret += sscanf(line, "TestProblemInitialMetallicityFraction  = %"FSYM, &TestProblemData.MetallicityField_Fraction);
@@ -180,6 +201,12 @@ int TestMultiStarParticleInitialize(FILE *fptr, FILE *Outfptr, HierarchyEntry &T
   if (TestMultiStarParticleSphereRadius <= 0.0)
     ENZO_FAIL("Error in TestMultiStarParticleInitialize: TestMultiStarParticleSphereRadius must be > 0");
 
+  if (TestMultiStarParticleUseSphProfile && TestMultiStarParticleSphProfileRadius <= 0.0)
+    ENZO_FAIL("Error in TestMultiStarParticleInitialize: TestMultiStarParticleSphProfileRadius must be > 0");
+
+  if (TestMultiStarParticleUseSphProfile && TestMultiStarParticleSphProfileAlpha <= 0.0)
+    ENZO_FAIL("Error in TestMultiStarParticleInitialize: TestMultiStarParticleSphProfileAlpha must be > 0");
+
   /* add gas velocity to internal energy to find total energy */
 
   float TotalEnergy = TestMultiStarParticleEnergy;
@@ -202,6 +229,11 @@ int TestMultiStarParticleInitialize(FILE *fptr, FILE *Outfptr, HierarchyEntry &T
                                           TestMultiStarParticleStarMass,
                                           TestMultiStarParticleStarVelocity,
                                           TestMultiStarParticleStarMetallicityFraction,
+                                          TestMultiStarParticleUseSphProfile,
+                                          TestMultiStarParticleSphProfileRadius,
+                                          TestMultiStarParticleSphProfileAlpha,
+                                          TestMultiStarParticleDensity,
+                                          TestMultiStarParticleEnergy,
                                           Initialdt) == FAIL)
     ENZO_FAIL("Error in TestMultiStarParticleInitializeGrid.\n");
 
@@ -271,6 +303,14 @@ int TestMultiStarParticleInitialize(FILE *fptr, FILE *Outfptr, HierarchyEntry &T
             TestMultiStarParticleSphereRadius);
     fprintf(Outfptr, "MetallicityField_Fraction = %"FSYM"\n",
             TestProblemData.MetallicityField_Fraction);
+    fprintf(Outfptr, "TestMultiStarParticleUseSphProfile = %"ISYM"\n",
+            TestMultiStarParticleUseSphProfile);
+    if (TestMultiStarParticleUseSphProfile) {
+      fprintf(Outfptr, "TestMultiStarParticleSphProfileRadius = %"PSYM"\n",
+              TestMultiStarParticleSphProfileRadius);
+      fprintf(Outfptr, "TestMultiStarParticleSphProfileAlpha = %"FSYM"\n",
+              TestMultiStarParticleSphProfileAlpha);
+    }
   }
 
   fprintf(stderr, "TestMultiStarParticleDensity = %"FSYM"\n",
@@ -283,6 +323,14 @@ int TestMultiStarParticleInitialize(FILE *fptr, FILE *Outfptr, HierarchyEntry &T
           TestMultiStarParticleSphereRadius);
   fprintf(stderr, "MetallicityField_Fraction = %"FSYM"\n",
           TestProblemData.MetallicityField_Fraction);
+  fprintf(stderr, "TestMultiStarParticleUseSphProfile = %"ISYM"\n",
+          TestMultiStarParticleUseSphProfile);
+  if (TestMultiStarParticleUseSphProfile) {
+    fprintf(stderr, "TestMultiStarParticleSphProfileRadius = %"PSYM"\n",
+            TestMultiStarParticleSphProfileRadius);
+    fprintf(stderr, "TestMultiStarParticleSphProfileAlpha = %"FSYM"\n",
+            TestMultiStarParticleSphProfileAlpha);
+  }
 
   return SUCCESS;
 }

--- a/src/enzo/TestMultiStarParticleInitialize.C
+++ b/src/enzo/TestMultiStarParticleInitialize.C
@@ -1,0 +1,288 @@
+/***********************************************************************
+/
+/  INITIALIZE A MULTI-STAR PARTICLE TEST
+/
+/  written by: Cassi Lochhaas
+/  date:       2026
+/  modified1:
+/
+/  PURPOSE:
+/    Initialize a multi-star particle test in a uniform medium.
+/    Particles are placed in a roughly spherical formation using the
+/    Fibonacci spiral algorithm, with user-controlled count and spacing.
+/
+/    Parameters:
+/      TestMultiStarParticleNParticles    -- number of star particles (default 50)
+/      TestMultiStarParticleSpacing       -- approx spacing between adjacent
+/                                           particles in code units (default 0.1);
+/                                           sets sphere radius as
+/                                           R = spacing * cbrt(3*N / (4*pi))
+/      TestMultiStarParticleCenter        -- center of the sphere (default 0.5 0.5 0.5)
+/      TestMultiStarParticleStarMass      -- mass per particle in solar masses (default 100)
+/      TestMultiStarParticleStarVelocity  -- velocity for all particles in km/s (default 0 0 0)
+/      TestMultiStarParticleStarMetallicityFraction -- metallicity fraction (default 0)
+/
+/  RETURNS: SUCCESS or FAIL
+/
+************************************************************************/
+
+#include <string.h>
+#include <stdio.h>
+#include <math.h>
+#include "ErrorExceptions.h"
+#include "macros_and_parameters.h"
+#include "typedefs.h"
+#include "global_data.h"
+#include "Fluxes.h"
+#include "GridList.h"
+#include "ExternalBoundary.h"
+#include "Grid.h"
+#include "Hierarchy.h"
+#include "TopGridData.h"
+
+int GetUnits(float *DensityUnits, float *LengthUnits,
+             float *TemperatureUnits, float *TimeUnits,
+             float *VelocityUnits, FLOAT Time);
+
+int TestMultiStarParticleInitialize(FILE *fptr, FILE *Outfptr, HierarchyEntry &TopGrid,
+                                    TopGridData &MetaData, float *Initialdt)
+{
+  char *DensName = "Density";
+  char *TEName   = "TotalEnergy";
+  char *GEName   = "GasEnergy";
+  char *Vel1Name = "x-velocity";
+  char *Vel2Name = "y-velocity";
+  char *Vel3Name = "z-velocity";
+  char *MetalName = "Metal_Density";
+  char *MetalIIName = "MetalSNII_Density";
+  char *MetalIaName = "MetalSNIa_Density";
+  char *MetalAGBName = "MetalAGB_Density";
+  char *MetalNSMName = "MetalNSM_Density";
+  char *ElectronName = "Electron_Density";
+  char *HIName    = "HI_Density";
+  char *HIIName   = "HII_Density";
+  char *HeIName   = "HeI_Density";
+  char *HeIIName  = "HeII_Density";
+  char *HeIIIName = "HeIII_Density";
+  char *HMName    = "HM_Density";
+  char *H2IName   = "H2I_Density";
+  char *H2IIName  = "H2II_Density";
+  char *DIName    = "DI_Density";
+  char *DIIName   = "DII_Density";
+  char *HDIName   = "HDI_Density";
+
+  char *TracerFluidO1Name = "TracerFluid01";
+  char *TracerFluidO2Name = "TracerFluid02";
+  char *TracerFluidO3Name = "TracerFluid03";
+  char *TracerFluidO4Name = "TracerFluid04";
+  char *TracerFluidO5Name = "TracerFluid05";
+  char *TracerFluidO6Name = "TracerFluid06";
+  char *TracerFluidO7Name = "TracerFluid07";
+  char *TracerFluidO8Name = "TracerFluid08";
+
+  /* declarations */
+
+  char  line[MAX_LINE_LENGTH];
+  int dim, ret;
+
+  /* set default parameters */
+
+  float TestMultiStarParticleDensity     = 1.0;
+  float TestMultiStarParticleEnergy      = -1.0;
+  float TestMultiStarParticleTemperature = -1.0;
+  float TestMultiStarParticleVelocity[3] = {0.0, 0.0, 0.0};
+  float TestMultiStarParticleBField[3]   = {0.0, 0.0, 0.0};
+
+  int   TestMultiStarParticleNParticles   = 50;
+  FLOAT TestMultiStarParticleSphereRadius = 0.1;
+  FLOAT TestMultiStarParticleCenter[3]    = {0.5, 0.5, 0.5};
+  float TestMultiStarParticleStarMass     = 100.0;
+  FLOAT TestMultiStarParticleStarVelocity[3] = {0.0, 0.0, 0.0};
+  float TestMultiStarParticleStarMetallicityFraction = 0.0;
+
+  int TestProblemUseMetallicityField = 1;
+  float TestProblemInitialMetallicityFraction = 2e-3; // 0.1 Zsun
+
+  TestProblemData.MultiSpecies = MultiSpecies;
+  TestProblemData.UseMetallicityField = TestProblemUseMetallicityField;
+  TestProblemData.MetallicityField_Fraction = TestProblemInitialMetallicityFraction;
+
+  /* read input from file */
+
+  while (fgets(line, MAX_LINE_LENGTH, fptr) != NULL) {
+
+    ret = 0;
+
+    /* read parameters */
+
+    ret += sscanf(line, "TestMultiStarParticleDensity = %"FSYM,
+                  &TestMultiStarParticleDensity);
+    ret += sscanf(line, "TestMultiStarParticleEnergy = %"FSYM,
+                  &TestMultiStarParticleEnergy);
+    ret += sscanf(line, "TestMultiStarParticleTemperature = %"FSYM,
+                  &TestMultiStarParticleTemperature);
+    ret += sscanf(line, "TestMultiStarParticleNParticles = %"ISYM,
+                  &TestMultiStarParticleNParticles);
+    ret += sscanf(line, "TestMultiStarParticleSphereRadius = %"PSYM,
+                  &TestMultiStarParticleSphereRadius);
+    ret += sscanf(line, "TestMultiStarParticleCenter = %"PSYM" %"PSYM" %"PSYM,
+                  &TestMultiStarParticleCenter[0],
+                  &TestMultiStarParticleCenter[1],
+                  &TestMultiStarParticleCenter[2]);
+    ret += sscanf(line, "TestMultiStarParticleStarMass = %"FSYM,
+                  &TestMultiStarParticleStarMass);
+    ret += sscanf(line, "TestMultiStarParticleStarVelocity = %"PSYM" %"PSYM" %"PSYM,
+                  &TestMultiStarParticleStarVelocity[0],
+                  &TestMultiStarParticleStarVelocity[1],
+                  &TestMultiStarParticleStarVelocity[2]);
+    ret += sscanf(line, "TestMultiStarParticleStarMetallicityFraction = %"FSYM,
+                  &TestMultiStarParticleStarMetallicityFraction);
+
+    ret += sscanf(line, "TestProblemUseMetallicityField  = %"ISYM, &TestProblemData.UseMetallicityField);
+    ret += sscanf(line, "TestProblemInitialMetallicityFraction  = %"FSYM, &TestProblemData.MetallicityField_Fraction);
+
+    ret += sscanf(line, "TestProblemInitialHIFraction  = %"FSYM, &TestProblemData.HI_Fraction);
+    ret += sscanf(line, "TestProblemInitialHIIFraction  = %"FSYM, &TestProblemData.HII_Fraction);
+    ret += sscanf(line, "TestProblemInitialHeIFraction  = %"FSYM, &TestProblemData.HeI_Fraction);
+    ret += sscanf(line, "TestProblemInitialHeIIFraction  = %"FSYM, &TestProblemData.HeII_Fraction);
+    ret += sscanf(line, "TestProblemInitialHeIIIIFraction  = %"FSYM, &TestProblemData.HeIII_Fraction);
+    ret += sscanf(line, "TestProblemHydrogenFractionByMass = %"FSYM, &TestProblemData.HydrogenFractionByMass);
+
+    /* if the line is suspicious, issue a warning */
+
+    if (ret == 0 && strstr(line, "=") && strstr(line, "TestMultiStarParticle")
+        && line[0] != '#')
+      fprintf(stderr, "warning: the following parameter line was not interpreted:\n%s\n", line);
+
+  } // end input from parameter file
+
+  /* use either the internal energy or the temperature parameters */
+
+  if ((TestMultiStarParticleEnergy > 0) && (TestMultiStarParticleTemperature > 0))
+    ENZO_FAIL("Error in TestMultiStarParticleInitialize: please specify only one of TestMultiStarParticleEnergy and TestMultiStarParticleTemperature");
+
+  if ((TestMultiStarParticleEnergy < 0) && (TestMultiStarParticleTemperature < 0))
+    ENZO_FAIL("Error in TestMultiStarParticleInitialize: please specify either TestMultiStarParticleEnergy or TestMultiStarParticleTemperature");
+
+  if (TestMultiStarParticleTemperature > 0) {
+    float DensityUnits, LengthUnits, TemperatureUnits, TimeUnits, VelocityUnits;
+    if (GetUnits(&DensityUnits, &LengthUnits, &TemperatureUnits, &TimeUnits,
+                 &VelocityUnits, MetaData.Time) == FAIL) {
+      fprintf(stderr, "Error in GetUnits.\n");
+      return FAIL;
+    }
+    TestMultiStarParticleEnergy = TestMultiStarParticleTemperature / TemperatureUnits / ((Gamma - 1.0) * 0.6);
+  }
+
+  if (TestMultiStarParticleNParticles < 1)
+    ENZO_FAIL("Error in TestMultiStarParticleInitialize: TestMultiStarParticleNParticles must be >= 1");
+
+  if (TestMultiStarParticleSphereRadius <= 0.0)
+    ENZO_FAIL("Error in TestMultiStarParticleInitialize: TestMultiStarParticleSphereRadius must be > 0");
+
+  /* add gas velocity to internal energy to find total energy */
+
+  float TotalEnergy = TestMultiStarParticleEnergy;
+  for (dim = 0; dim < MetaData.TopGridRank; dim++)
+    TotalEnergy += 0.5 * POW(TestMultiStarParticleVelocity[dim], 2);
+
+  /* set up uniform grid */
+
+  if (TopGrid.GridData->InitializeUniformGrid(TestMultiStarParticleDensity,
+                                              TotalEnergy,
+                                              TestMultiStarParticleEnergy,
+                                              TestMultiStarParticleVelocity,
+                                              TestMultiStarParticleBField) == FAIL)
+    ENZO_FAIL("Error in InitializeUniformGrid.");
+
+  if (TopGrid.GridData->
+      TestMultiStarParticleInitializeGrid(TestMultiStarParticleNParticles,
+                                          TestMultiStarParticleSphereRadius,
+                                          TestMultiStarParticleCenter,
+                                          TestMultiStarParticleStarMass,
+                                          TestMultiStarParticleStarVelocity,
+                                          TestMultiStarParticleStarMetallicityFraction,
+                                          Initialdt) == FAIL)
+    ENZO_FAIL("Error in TestMultiStarParticleInitializeGrid.\n");
+
+  /* set up field names and units */
+
+  int count = 0;
+  DataLabel[count++] = DensName;
+  DataLabel[count++] = TEName;
+  if (DualEnergyFormalism)
+    DataLabel[count++] = GEName;
+  DataLabel[count++] = Vel1Name;
+  DataLabel[count++] = Vel2Name;
+  DataLabel[count++] = Vel3Name;
+  if (TestProblemData.MultiSpecies) {
+    DataLabel[count++] = ElectronName;
+    DataLabel[count++] = HIName;
+    DataLabel[count++] = HIIName;
+    DataLabel[count++] = HeIName;
+    DataLabel[count++] = HeIIName;
+    DataLabel[count++] = HeIIIName;
+    if (TestProblemData.MultiSpecies > 1) {
+      DataLabel[count++] = HMName;
+      DataLabel[count++] = H2IName;
+      DataLabel[count++] = H2IIName;
+    }
+    if (TestProblemData.MultiSpecies > 2) {
+      DataLabel[count++] = DIName;
+      DataLabel[count++] = DIIName;
+      DataLabel[count++] = HDIName;
+    }
+  }
+  if (TestProblemData.UseMetallicityField)
+    DataLabel[count++] = MetalName;
+    if (StarMakerTypeIaSNe || StarFeedbackTrackMetalSources)
+      DataLabel[count++] = MetalIaName;
+    if (StarFeedbackTrackMetalSources) {
+      DataLabel[count++] = MetalIIName;
+      DataLabel[count++] = MetalAGBName;
+      DataLabel[count++] = MetalNSMName;
+    }
+
+  if (UseTracerFluid) {
+    if (NumberOfTracerFluidFields >= 1) DataLabel[count++] = TracerFluidO1Name;
+    if (NumberOfTracerFluidFields >= 2) DataLabel[count++] = TracerFluidO2Name;
+    if (NumberOfTracerFluidFields >= 3) DataLabel[count++] = TracerFluidO3Name;
+    if (NumberOfTracerFluidFields >= 4) DataLabel[count++] = TracerFluidO4Name;
+    if (NumberOfTracerFluidFields >= 5) DataLabel[count++] = TracerFluidO5Name;
+    if (NumberOfTracerFluidFields >= 6) DataLabel[count++] = TracerFluidO6Name;
+    if (NumberOfTracerFluidFields >= 7) DataLabel[count++] = TracerFluidO7Name;
+    if (NumberOfTracerFluidFields == 8) DataLabel[count++] = TracerFluidO8Name;
+  }
+
+  int j;
+  for (j = 0; j < count; j++)
+    DataUnits[j] = NULL;
+
+  /* Write parameters to parameter output file */
+
+  if (MyProcessorNumber == ROOT_PROCESSOR) {
+    fprintf(Outfptr, "TestMultiStarParticleDensity = %"FSYM"\n",
+            TestMultiStarParticleDensity);
+    fprintf(Outfptr, "TestMultiStarParticleEnergy = %"FSYM"\n",
+            TestMultiStarParticleEnergy);
+    fprintf(Outfptr, "TestMultiStarParticleNParticles = %"ISYM"\n",
+            TestMultiStarParticleNParticles);
+    fprintf(Outfptr, "TestMultiStarParticleSphereRadius = %"PSYM"\n",
+            TestMultiStarParticleSphereRadius);
+    fprintf(Outfptr, "MetallicityField_Fraction = %"FSYM"\n",
+            TestProblemData.MetallicityField_Fraction);
+  }
+
+  fprintf(stderr, "TestMultiStarParticleDensity = %"FSYM"\n",
+          TestMultiStarParticleDensity);
+  fprintf(stderr, "TestMultiStarParticleEnergy = %"FSYM"\n",
+          TestMultiStarParticleEnergy);
+  fprintf(stderr, "TestMultiStarParticleNParticles = %"ISYM"\n",
+          TestMultiStarParticleNParticles);
+  fprintf(stderr, "TestMultiStarParticleSphereRadius = %"PSYM"\n",
+          TestMultiStarParticleSphereRadius);
+  fprintf(stderr, "MetallicityField_Fraction = %"FSYM"\n",
+          TestProblemData.MetallicityField_Fraction);
+
+  return SUCCESS;
+}

--- a/src/enzo/star_feedback2_tab.F
+++ b/src/enzo/star_feedback2_tab.F
@@ -115,7 +115,7 @@ c     Loop over particles
 c
 c      write(6,*) 'star_feedback2: start'
       do n=1, npart
-         if (tcp(n) .gt. 0 .and. mp(n) .gt.0 .and. type(n) .eq. 2) then
+         if (tcp(n) .gt. 0 .and. mp(n) .gt. 0 .and. type(n) .eq. 2) then
 c
 c         Compute index of the cell that the star particle
 c           resides in.

--- a/src/enzo/star_feedback2_tab.F
+++ b/src/enzo/star_feedback2_tab.F
@@ -115,7 +115,7 @@ c     Loop over particles
 c
 c      write(6,*) 'star_feedback2: start'
       do n=1, npart
-         if (tcp(n) .gt. 0 .and. mp(n) .gt. 0 .and. type(n) .eq. 2) then
+         if (tcp(n) .gt. 0 .and. mp(n) .gt.0 .and. type(n) .eq. 2) then
 c
 c         Compute index of the cell that the star particle
 c           resides in.

--- a/src/enzo/star_feedback6.F
+++ b/src/enzo/star_feedback6.F
@@ -155,7 +155,7 @@ c
 c  Locals
 c
       INTG_PREC n, ic, jc, kc, ip, jp, kp,
-     &     i, j, k, cellstep, stepk, stepj
+     &     i, j, k, cellstep, stepk, stepj, fbuff
       R_PREC mform, energy, energy_ii, energy_ia,
      &     m_eject, meject_ii, meject_ia, yield, minitial, xv1, xv2,
      &     mass_per_cell,
@@ -172,7 +172,7 @@ c
       R_PREC energy_per_cell(2*distrad+1,2*distrad+1,2*distrad+1)
       R_PREC energy_per_cell1(2*distrad+1,2*distrad+1,2*distrad+1)
       R_PREC Z_avg, n_avg, Z_floor,
-     &	  realmass, mu_cell, fbuff, add_therm
+     &	  realmass, mu_cell, add_therm
       R_PREC n_cell, Z_cell
       R_PREC te_sum, ke_sum, ge_sum, mom_sum, mass_sum,
      &     mass_term, vel_mag, delta_ge, add_ge

--- a/src/enzo/star_feedback6.F
+++ b/src/enzo/star_feedback6.F
@@ -117,7 +117,7 @@ c-----------------------------------------------------------------------
       implicit none
 #include "fortran_types.def"
 c-----------------------------------------------------------------------
-#define FORTRAN_DEBUG
+#define NO_FORTRAN_DEBUG
 c
 c  Arguments
 c
@@ -1061,6 +1061,7 @@ c
 c           mom_per_cell has units of mass*velocity/volume
 #ifdef FORTRAN_DEBUG
                write(7,*) 'energy_per_cell', energy_per_cell
+     &                  *dunits*(dx*x1)**3._RKIND*vunits**2._RKIND
 #endif
 c
 c     If not injecting any momentum or energy, skip
@@ -1347,6 +1348,10 @@ c
      &             energy_inj*dunits*
      &             vunits**2._RKIND*dx**3._RKIND*x1**3._RKIND,
      &             add_therm*dunits*
+     &             vunits**2._RKIND*dx**3._RKIND*x1**3._RKIND,
+     &             kin_energy_dummy*dunits*
+     &             vunits**2._RKIND*dx**3._RKIND*x1**3._RKIND,
+     &             kin_energy_inj*dunits*
      &             vunits**2._RKIND*dx**3._RKIND*x1**3._RKIND,
      &             pSNmass_grid(ic,jc,kc)*
      &             (dunits*(x1*dx)**3._RKIND)/SolarMass,

--- a/src/enzo/star_feedback6.F
+++ b/src/enzo/star_feedback6.F
@@ -307,8 +307,10 @@ c     Make sure particle is in grid, skip if not
             if (xp(n) .lt. xstart .or. xp(n) .gt. xstart+dx*nx .or.
      &          yp(n) .lt. ystart .or. yp(n) .gt. ystart+dx*ny .or.
      &          zp(n) .lt. zstart .or. zp(n) .gt. zstart+dx*nz) then
+#ifdef FORTRAN_DEBUG
                write(7,*) 'warning: star particle out of grid',
      &              xp(n),yp(n),zp(n), xstart, ystart, zstart
+#endif
                goto 10
             endif
 c
@@ -666,6 +668,14 @@ c
             jc = int(ypos) + 1_IKIND
             kc = int(zpos) + 1_IKIND
 c
+c     Clamp feedback center so feedback region [ic-distrad, ic+distrad]
+c     stays within the allocated array, regardless of floating-point
+c     rounding in the position-to-index conversion above or parameter values.
+c
+            ic = max(distrad+1_IKIND, min(nx-distrad, ic))
+            jc = max(distrad+1_IKIND, min(ny-distrad, jc))
+            kc = max(distrad+1_IKIND, min(nz-distrad, kc))
+c
 c     Put nsn, meject, mzeject, and weighted particle velocity values on grid at this location
 c     Weight average velocity for SNe by number of SNe going off in each particle
 c
@@ -736,11 +746,14 @@ c     This will be used as the "particle velocity"
 c     when translating the momentum into the particle frame.
 c
 c
-c     Loop over the feedback grids, avoiding the edges
+c     Loop over the feedback grids, avoiding the edges.
+c     The bounds ibuff+distrad+1 to n*-ibuff-distrad ensure that the
+c     feedback region [ic-distrad, ic+distrad] always stays within the
+c     allocated array for any distrad or ibuff value.
 c
-      do kc=2_IKIND, nz-1_IKIND
-         do jc=2_IKIND, ny-1_IKIND
-            do ic=2_IKIND, nx-1_IKIND
+      do kc=ibuff+distrad+1_IKIND, nz-ibuff-distrad
+         do jc=ibuff+distrad+1_IKIND, ny-ibuff-distrad
+            do ic=ibuff+distrad+1_IKIND, nx-ibuff-distrad
 c
 c ====================================================================
 c     BEGIN PRE-SUPERNOVA FEEDBACK
@@ -757,6 +770,7 @@ c     before momentum is added.  This
 c     is needed at the end of the calculation to update the
 c     total energy (te) field.
 c
+               ke_b_wind = 0._RKIND
                do k = -distrad, +distrad
                   stepk = abs(k)
                   do j = -distrad, +distrad
@@ -1053,6 +1067,8 @@ c     Compute the mass and momentum that this cell is responsible for
 c     injecting
 c
                mass_per_cell = meject_grid(ic,jc,kc)/distcells
+               mom_per_cell = 0._RKIND
+               energy_per_cell = 0._RKIND
                call get_mom_per_cell(d, mass_per_cell,
      &                  distcells, mom_per_cell, energy_per_cell,
      &                  nsn_grid(ic,jc,kc), d(ic,jc,kc), dx, x1,
@@ -1096,6 +1112,7 @@ c     before momentum is added.  This
 c     is needed at the end of the calculation to update the
 c     total energy (te) field.
 c
+               ke_before = 0._RKIND
                do k = -distrad, +distrad
                   stepk = abs(k)
                   do j = -distrad, +distrad

--- a/src/enzo/star_feedback6.F
+++ b/src/enzo/star_feedback6.F
@@ -672,9 +672,9 @@ c     Clamp feedback center so feedback region [ic-distrad, ic+distrad]
 c     stays within the allocated array, regardless of floating-point
 c     rounding in the position-to-index conversion above or parameter values.
 c
-            ic = max(distrad+1_IKIND, min(nx-distrad, ic))
-            jc = max(distrad+1_IKIND, min(ny-distrad, jc))
-            kc = max(distrad+1_IKIND, min(nz-distrad, kc))
+            ic = max(fbuff+1_IKIND, min(nx-fbuff, ic))
+            jc = max(fbuff+1_IKIND, min(ny-fbuff, jc))
+            kc = max(fbuff+1_IKIND, min(nz-fbuff, kc))
 c
 c     Put nsn, meject, mzeject, and weighted particle velocity values on grid at this location
 c     Weight average velocity for SNe by number of SNe going off in each particle

--- a/src/enzo/star_feedback6.F
+++ b/src/enzo/star_feedback6.F
@@ -764,7 +764,8 @@ c
                      do i = -distrad, +distrad
                         cellstep = stepj + abs(i)
                         if (cellstep .le. diststep) then
-                           ke_b_wind(i+distrad+1,j+distrad+1,k+distrad+1)=
+                           ke_b_wind(i+distrad+1, j+distrad+1,
+     &                        k+distrad+1)=
      &                         0.5_RKIND*d(ic+i, jc+j, kc+k)*
      &                                 (u(ic+i ,jc+j ,kc+k)**2_IKIND +
      &                                  v(ic+i ,jc+j ,kc+k)**2_IKIND +
@@ -1102,7 +1103,8 @@ c
                      do i = -distrad, +distrad
                         cellstep = stepj + abs(i)
                         if (cellstep .le. diststep) then
-                           ke_before(i+distrad+1,j+distrad+1,k+distrad+1)=
+                           ke_before(i+distrad+1, j+distrad+1,
+     &                        k+distrad+1)=
      &                         0.5_RKIND*d(ic+i, jc+j, kc+k)*
      &                                 (u(ic+i ,jc+j ,kc+k)**2_IKIND +
      &                                  v(ic+i ,jc+j ,kc+k)**2_IKIND +
@@ -1416,7 +1418,8 @@ c
         ergs_51_sqr = 10._RKIND**(51._RKIND/2._RKIND)
         Nnbors = real(distcells, RKIND) - 1._RKIND ! 26
         betaSN = 1._RKIND/real(distcells, RKIND)   ! 1/27
-        Mej = mass_per_cell*real(distcells, RKIND)*dunits*(x1*dx)**3._RKIND
+        Mej = mass_per_cell*real(distcells, RKIND) * 
+     &     dunits*(x1*dx)**3._RKIND
         SN_energy = nsn*10**51._RKIND/Nnbors
         chi_th = 69.58_RKIND*(nsn)**(-2._RKIND/17._RKIND) * 
      &               (n_avg)**(-4._RKIND/17._RKIND) * 
@@ -1479,12 +1482,20 @@ c        and inject thermal into this cell equal to total - kinetic
      &                    *(dunits*(dx*x1)**3._RKIND*vunits**2._RKIND)
 #endif
                   else
+c        Unresolved, only momentum
                      pSN = mom_mult * 3.e10_RKIND*SolarMass * 
      &                        (nsn)**(16._RKIND/17._RKIND) * 
      &                        (n_avg)**(-2._RKIND/17._RKIND) * 
      &                        (Z_floor)**(-0.14_RKIND)
-                     energy_per_cell(i+distrad+1,
-     &                  j+distrad+1,k+distrad+1) = 0._RKIND
+c        ... unless mom_mult = 0, to mimic thermal-only for testing
+                     if (mom_mult .eq. 0._RKIND) then
+                        energy_per_cell(i+distrad+1,
+     &                    j+distrad+1,k+distrad+1) = SN_energy 
+     &                    /(dunits*(dx*x1)**3._RKIND*vunits**2._RKIND)
+                     else
+                        energy_per_cell(i+distrad+1,
+     &                    j+distrad+1,k+distrad+1) = 0._RKIND
+                     endif
 #ifdef FORTRAN_DEBUG
                      write(7,*) 'gt chi_th, pSN:',
      &                        pSN/SolarMass/1e5_RKIND

--- a/src/enzo/star_feedback6.F
+++ b/src/enzo/star_feedback6.F
@@ -12,6 +12,7 @@ c
      &               idual, imetal, imulti_metals, imethod, 
      &               dt, dx, t, z, procnum,
      &               dunits, x1, vunits, t1, m_eject_frac, yield,
+     &               distrad, diststep, distcells,
      &               npart, xstart, ystart, zstart, ibuff,
      &               xp, yp, zp, up, vp, wp,
      &               mp, tdp, tcp, metalf, type,
@@ -33,11 +34,11 @@ c  	this is a copy of star_maker3mom.F that has been modifed to
 c       calculate the amount of momentum to inject from properties
 c       of the host and surrounding cells, following Kimm & Cen (2014)
 c       and Kimm et al. (2015).
-c       The momentum is then injected into a cube of 27 cells centered
-c       on the host cell of the particle.
+c       The momentum is then injected into a region centered on the
+c       host particle and defined by distrad and diststep.
 c
-c       Currently, the only momentum injection is due to Type II and
-c       Type Ia SNe. Momentum injection from stellar winds is WIP.
+c       Momentum injection is due to supernovae (Type II and
+c       Type Ia) and stellar winds (optional).
 c
 c  INPUTS:
 c
@@ -66,6 +67,9 @@ c               if exptime >= 0, a flag for whether the discrete
 c               explosion has occurred
 c    tcp      - creation time of particle (-1 if not a star particle)
 c    metalf   - star particle metal fraction
+c    distrad  - feedback distribution radius in cells
+c    diststep - distance in walking steps to deposit feedback
+c    distcells - total number of cells over which to distribute feedback
 c    npart    - particle array size specified by calling routine
 c    m_eject_frac  - fraction of stellar mass ejected back to gas
 c    yield    - fraction of stellar mass that is converted to metals
@@ -113,7 +117,7 @@ c-----------------------------------------------------------------------
       implicit none
 #include "fortran_types.def"
 c-----------------------------------------------------------------------
-#define NO_FORTRAN_DEBUG
+#define FORTRAN_DEBUG
 c
 c  Arguments
 c
@@ -146,14 +150,15 @@ c
       R_PREC    pSNtabMass(pSNntabAge, pSNntabZ)
       R_PREC    pSNtabMetal(pSNntabAge, pSNntabZ)
       R_PREC    pSNtabMom(pSNntabAge, pSNntabZ)
+      INTG_PREC distrad, diststep, distcells
 c
 c  Locals
 c
       INTG_PREC n, ic, jc, kc, ip, jp, kp,
-     &     i, j, k
+     &     i, j, k, cellstep, stepk, stepj
       R_PREC mform, energy, energy_ii, energy_ia,
      &     m_eject, meject_ii, meject_ia, yield, minitial, xv1, xv2,
-     &     distrad,distcells, mass_per_cell,
+     &     mass_per_cell,
      &     mass_before, mass_dummy,
      &     kin_energy_before, mom_dummy, mom_inj, energy_inj,
      &     delta_ke, ke_injected, ke_after, kin_energy_inj,
@@ -162,8 +167,10 @@ c
      &     kin_energy_dummy
       R_PREC xfcshift, yfcshift, zfcshift, xfc, yfc, zfc,
      &     xpos, ypos, zpos
-      R_PREC ke_before(3,3,3), mom_per_cell(3,3,3)
-      R_PREC energy_per_cell(3,3,3), energy_per_cell1(3,3,3)
+      R_PREC ke_before(2*distrad+1,2*distrad+1,2*distrad+1)
+      R_PREC mom_per_cell(2*distrad+1,2*distrad+1,2*distrad+1)
+      R_PREC energy_per_cell(2*distrad+1,2*distrad+1,2*distrad+1)
+      R_PREC energy_per_cell1(2*distrad+1,2*distrad+1,2*distrad+1)
       R_PREC Z_avg, n_avg, Z_floor,
      &	  realmass, mu_cell, fbuff, add_therm
       R_PREC n_cell, Z_cell
@@ -171,8 +178,13 @@ c
      &     mass_term, vel_mag, delta_ge, add_ge
       R_PREC mz_eject, mzeject_ii, mzeject_ia
       R_PREC metal_per_cell, metal_ii_per_cell, metal_ia_per_cell
-      R_PREC u1(3,3,3), v1(3,3,3), w1(3,3,3), d1(3,3,3),
-     &     te1(3,3,3), ge1(3,3,3), metal1(3,3,3)
+      R_PREC u1(2*distrad+1,2*distrad+1,2*distrad+1)
+      R_PREC v1(2*distrad+1,2*distrad+1,2*distrad+1)
+      R_PREC w1(2*distrad+1,2*distrad+1,2*distrad+1)
+      R_PREC d1(2*distrad+1,2*distrad+1,2*distrad+1)
+      R_PREC te1(2*distrad+1,2*distrad+1,2*distrad+1)
+      R_PREC ge1(2*distrad+1,2*distrad+1,2*distrad+1)
+      R_PREC metal1(2*distrad+1,2*distrad+1,2*distrad+1)
       R_PREC nsn_grid(nx,ny,nz), meject_grid(nx,ny,nz),
      &     mzeject_grid(nx,ny,nz), mzeject_ii_grid(nx,ny,nz),
      &     mzeject_ia_grid(nx,ny,nz), up_grid(nx,ny,nz),
@@ -182,7 +194,7 @@ c
      &      pSNvp_grid(nx,ny,nz), pSNwp_grid(nx,ny,nz)
       R_PREC up_avg, vp_avg, wp_avg, up_avg_w, vp_avg_w, wp_avg_w
       R_PREC wind_mass, wind_metal, wind_mom
-      R_PREC ke_b_wind(3,3,3)
+      R_PREC ke_b_wind(2*distrad+1,2*distrad+1,2*distrad+1)
       R_PREC mass_b_wind, kin_energy_b_wind, mom_b_wind,
      &       mass_per_cell_w, mom_per_cell_w, metal_per_cell_w,
      &       mass_dummy_w, kin_energy_dummy_w, mom_dummy_w, mass_end_w,
@@ -273,13 +285,6 @@ c
             enddo
          enddo
       enddo
-c
-c     Assuming 3x3x3 cube, calculate cell distribution
-c     NOTE: This feedback scheme is not written to be used with
-c     any other cell distribution!!
-c
-      distrad = 3_IKIND
-      distcells = distrad**3_IKIND
 c
 c-----------------------------------------------------------------------
 c
@@ -610,7 +615,7 @@ c
             xfc = xp(n)
             yfc = yp(n)
             zfc = zp(n)
-            fbuff = ibuff + 2._RKIND
+            fbuff = ibuff + distrad
 c
 c     Check bounds - if star particle is near grid edge
 c     then shift center of feedback region
@@ -752,14 +757,19 @@ c     before momentum is added.  This
 c     is needed at the end of the calculation to update the
 c     total energy (te) field.
 c
-               do k = -1_IKIND, +1_IKIND
-                  do j = -1_IKIND, +1_IKIND
-                     do i = -1_IKIND, +1_IKIND
-                        ke_b_wind(i+2, j+2, k+2) = 
-     &                      0.5_RKIND*d(ic+i, jc+j, kc+k)*
-     &                              (u(ic+i ,jc+j ,kc+k)**2_IKIND + 
-     &                               v(ic+i ,jc+j ,kc+k)**2_IKIND + 
-     &                               w(ic+i ,jc+j ,kc+k)**2_IKIND)
+               do k = -distrad, +distrad
+                  stepk = abs(k)
+                  do j = -distrad, +distrad
+                     stepj = stepk + abs(j)
+                     do i = -distrad, +distrad
+                        cellstep = stepj + abs(i)
+                        if (cellstep .le. diststep) then
+                           ke_b_wind(i+distrad+1,j+distrad+1,k+distrad+1)=
+     &                         0.5_RKIND*d(ic+i, jc+j, kc+k)*
+     &                                 (u(ic+i ,jc+j ,kc+k)**2_IKIND +
+     &                                  v(ic+i ,jc+j ,kc+k)**2_IKIND +
+     &                                  w(ic+i ,jc+j ,kc+k)**2_IKIND)
+                        endif
                      enddo
                   enddo
                enddo
@@ -776,12 +786,13 @@ c
                wp_avg_w = pSNwp_grid(ic,jc,kc)/pSNmass_grid(ic,jc,kc)
 c     Convert velocities into momenta and shift to frame of average velocity
                call momentum_convert(u, v, w, d, up_avg_w, vp_avg_w,
-     &                    wp_avg_w, nx, ny, nz, ic, jc, kc, 
-     &                    +1_IKIND)
+     &                    wp_avg_w, nx, ny, nz, ic, jc, kc,
+     &                    +1_IKIND, distrad, diststep)
 c     Sum mass, energy, and momentum before
                call sum_energy_mom(u, v, w, d, nx, ny, nz,
      &            ic, jc, kc,
-     &            mass_b_wind, kin_energy_b_wind, mom_b_wind)
+     &            mass_b_wind, kin_energy_b_wind, mom_b_wind,
+     &            distrad, diststep)
 #ifdef FORTRAN_DEBUG
                write(7,*) 'up_w, vp_w, wp_w',
      &            up_avg_w*vunits/1e5_IKIND,
@@ -801,41 +812,52 @@ c
 c
 c     Zero dummy velocity, energy, and metallicity fields
 c
-               do k = -1_IKIND, 1_IKIND
-                  do j = -1_IKIND, 1_IKIND
-                     do i = -1_IKIND, 1_IKIND
-                        u1(i+2,j+2,k+2) = 0._RKIND
-                        v1(i+2,j+2,k+2) = 0._RKIND
-                        w1(i+2,j+2,k+2) = 0._RKIND
-                        d1(i+2,j+2,k+2) = d(i+ic,j+jc,k+kc)
-                        ge1(i+2,j+2,k+2) = 0._RKIND
-                        te1(i+2,j+2,k+2) = 0._RKIND
-                        metal1(i+2,j+2,k+2) = 0._RKIND
+               do k = -distrad, distrad
+                  do j = -distrad, distrad
+                     do i = -distrad, distrad
+                        u1(i+distrad+1,j+distrad+1,k+distrad+1)=0._RKIND
+                        v1(i+distrad+1,j+distrad+1,k+distrad+1)=0._RKIND
+                        w1(i+distrad+1,j+distrad+1,k+distrad+1)=0._RKIND
+                        d1(i+distrad+1,j+distrad+1,k+distrad+1) =
+     &                     d(i+ic,j+jc,k+kc)
+                        ge1(i+distrad+1,j+distrad+1,k+distrad+1) = 
+     &                     0._RKIND
+                        te1(i+distrad+1,j+distrad+1,k+distrad+1) = 
+     &                     0._RKIND
+                        metal1(i+distrad+1,j+distrad+1,k+distrad+1) =
+     &                     0._RKIND
                      enddo
                   enddo
                enddo
 c
 c     Now add mass and momentum terms to local dummy fields
-c              
+c
                mass_per_cell_w = pSNmass_grid(ic,jc,kc)/distcells
                mom_per_cell_w = pSNmom_grid(ic,jc,kc)
      &                              /(distcells-1_IKIND)
                metal_per_cell_w = pSNmetal_grid(ic,jc,kc)/distcells
-               call add_preSN_feedback(u1, v1, w1, d1, ge1, te1, metal1, 
-     &                        3_IKIND, 3_IKIND, 3_IKIND,
-     &                        2_IKIND, 2_IKIND, 2_IKIND,
+               call add_preSN_feedback(u1, v1, w1, d1, ge1, te1, metal1,
+     &                        2_IKIND*distrad+1_IKIND,
+     &                        2_IKIND*distrad+1_IKIND,
+     &                        2_IKIND*distrad+1_IKIND,
+     &                        distrad+1_IKIND, distrad+1_IKIND,
+     &                        distrad+1_IKIND,
      &                        imetal, imulti_metals, idual,
      &                        kick_cap, preSNmom,
      &                        mass_per_cell_w, mom_per_cell_w,
-     &                        metal_per_cell_w, dx, x1, dunits, vunits)
+     &                        metal_per_cell_w, dx, x1, dunits, vunits,
+     &                        distrad, diststep)
 c
 c     Calculate mass and energy in dummy fields
 c
                call sum_energy_mom(u1, v1, w1, d1,
-     &                        3_IKIND, 3_IKIND, 3_IKIND,
-     &                        2_IKIND, 2_IKIND, 2_IKIND,
-     &                        mass_dummy_w, kin_energy_dummy_w, 
-     &                        mom_dummy_w)
+     &                        2_IKIND*distrad+1_IKIND,
+     &                        2_IKIND*distrad+1_IKIND,
+     &                        2_IKIND*distrad+1_IKIND,
+     &                        distrad+1_IKIND, distrad+1_IKIND,
+     &                        distrad+1_IKIND,
+     &                        mass_dummy_w, kin_energy_dummy_w,
+     &                        mom_dummy_w, distrad, diststep)
 #ifdef FORTRAN_DEBUG
                write(7,*) "m dummy wind:", mass_dummy_w*
      &               (dunits*(x1*dx)**3._RKIND)/SolarMass
@@ -853,13 +875,15 @@ c
      &                        kick_cap, preSNmom,
      &                        mass_per_cell_w, mom_per_cell_w,
      &                        metal_per_cell_w,
-     &                        dx, x1, dunits, vunits)
+     &                        dx, x1, dunits, vunits,
+     &                        distrad, diststep)
 c
 c     Calculate the mass and energy in the affected region again.
 c
                call sum_energy_mom(u, v, w, d, nx, ny, nz,
      &                         ic, jc, kc,
-     &                         mass_end_w, kin_energy_end_w, mom_end_w)
+     &                         mass_end_w, kin_energy_end_w, mom_end_w,
+     &                         distrad, diststep)
 #ifdef FORTRAN_DEBUG
                write(7,*) "m end wind:", mass_end_w*
      &               (dunits*(dx*x1)**3._RKIND)/SolarMass
@@ -891,23 +915,29 @@ c
 c
 c           Convert momenta back to velocities and transform back to lab frame
 c
-               call momentum_convert(u, v, w, d, up_avg_w, vp_avg_w, 
-     &               wp_avg_w, nx, ny, nz, ic, jc, kc, -1_IKIND)
+               call momentum_convert(u, v, w, d, up_avg_w, vp_avg_w,
+     &               wp_avg_w, nx, ny, nz, ic, jc, kc, -1_IKIND,
+     &               distrad, diststep)
 c
 c           Add the change in the kinetic energy to the total energy field
-c     
-               do k = -1_IKIND, +1_IKIND
-                  do j = -1_IKIND, +1_IKIND
-                     do i = -1_IKIND, +1_IKIND
-                        vel_mag = (u(ic+i ,jc+j ,kc+k)**2_IKIND + 
-     &                    v(ic+i ,jc+j ,kc+k)**2_IKIND + 
-     &                    w(ic+i ,jc+j ,kc+k)**2_IKIND)**0.5_RKIND
-                        ke_after_w = 0.5_RKIND * d(ic+i, jc+j, kc+k) * 
-     &                    vel_mag**2_IKIND
-                        delta_ke_w = ke_after_w - 
-     &                        ke_b_wind(i+2,j+2,k+2)
-                        te(ic+i,jc+j,kc+k) = te(ic+i,jc+j,kc+k) +
-     &                     delta_ke_w/d(ic+i,jc+j,kc+k)
+c
+               do k = -distrad, +distrad
+                  stepk = abs(k)
+                  do j = -distrad, +distrad
+                     stepj = stepk + abs(j)
+                     do i = -distrad, +distrad
+                        cellstep = stepj + abs(i)
+                        if (cellstep .le. diststep) then
+                           vel_mag = (u(ic+i ,jc+j ,kc+k)**2_IKIND +
+     &                       v(ic+i ,jc+j ,kc+k)**2_IKIND +
+     &                       w(ic+i ,jc+j ,kc+k)**2_IKIND)**0.5_RKIND
+                           ke_after_w = 0.5_RKIND *
+     &                       d(ic+i, jc+j, kc+k) * vel_mag**2_IKIND
+                           delta_ke_w = ke_after_w -
+     &                    ke_b_wind(i+distrad+1,j+distrad+1,k+distrad+1)
+                           te(ic+i,jc+j,kc+k) = te(ic+i,jc+j,kc+k) +
+     &                        delta_ke_w/d(ic+i,jc+j,kc+k)
+                        endif
                      enddo
                   enddo
                enddo
@@ -922,7 +952,8 @@ c     will be wrong here because velocities haven't been converted to
 c     momentum, but we only care about mass for this debugging check
                call sum_energy_mom(u, v, w, d, nx, ny, nz,
      &            ic, jc, kc,
-     &            mass_b_wind, kin_energy_b_wind, mom_b_wind)
+     &            mass_b_wind, kin_energy_b_wind, mom_b_wind,
+     &            distrad, diststep)
                write(7,*) "m before wind:", mass_b_wind*
      &               (dunits*(x1*dx)**3._RKIND)/SolarMass
 c
@@ -935,14 +966,16 @@ c
      &                        kick_cap, preSNmom,
      &                        mass_per_cell_w, 0._RKIND,
      &                        metal_per_cell_w,
-     &                        dx, x1, dunits, vunits)
+     &                        dx, x1, dunits, vunits,
+     &                        distrad, diststep)
 #ifdef FORTRAN_DEBUG
 c     Sum mass, energy, and momentum after. Note mom and KE calculations
 c     will be wrong here because velocities haven't been converted to
 c     momentum, but we only care about mass for this debugging check
                call sum_energy_mom(u, v, w, d, nx, ny, nz,
      &            ic, jc, kc,
-     &            mass_end_w, kin_energy_end_w, mom_end_w)
+     &            mass_end_w, kin_energy_end_w, mom_end_w,
+     &            distrad, diststep)
                write(7,*) "mass_per_cell_w:", mass_per_cell_w*
      &               (dunits*(x1*dx)**3._RKIND)/SolarMass
                write(7,*) "m after wind:", mass_end_w*
@@ -963,9 +996,13 @@ c     Compute average density and metallicity around this cell
 c     
                Z_avg = 0._RKIND
                n_avg = 0._RKIND
-               do k = -1_IKIND,1_IKIND
-                  do j = -1_IKIND,1_IKIND
-                     do i = -1_IKIND,1_IKIND
+               do k = -distrad, distrad
+                  stepk = abs(k)
+                  do j = -distrad, distrad
+                     stepj = stepk + abs(j)
+                     do i = -distrad, distrad
+                        cellstep = stepj + abs(i)
+                        if (cellstep .le. diststep) then
                         Z_cell = metal(ic+i,jc+j,kc+k)
                         mu_cell = mu(ic+i,jc+j,kc+k)
 c
@@ -990,7 +1027,7 @@ c
 c        Z_avg is average metallicity, so convert metal fraction to metallicity
 c        by assuming 0.02 is Zsun
                         Z_avg = Z_avg + Z_cell/0.02_RKIND
-                        n_avg = n_avg + 
+                        n_avg = n_avg +
      &                     d(ic+i,jc+j,kc+k)*dunits*
      &                     mu_cell/mass_h
 #ifdef FORTRAN_DEBUG
@@ -998,6 +1035,7 @@ c        by assuming 0.02 is Zsun
      &                       mu_cell, Z_cell, d(ic+i,jc+j,kc+k)*dunits,
      &                       d(ic+i,jc+j,kc+k)*dunits*mu_cell/mass_h
 #endif
+                        endif
                      enddo
                   enddo
                enddo
@@ -1019,7 +1057,7 @@ c
      &                  nsn_grid(ic,jc,kc), d(ic,jc,kc), dx, x1,
      &                  n_avg, Z_floor, dunits, vunits, t1,
      &                  nx, ny, nz, ic, jc, kc,
-     &                  mom_mult)
+     &                  mom_mult, distrad, diststep)
 c           mom_per_cell has units of mass*velocity/volume
 #ifdef FORTRAN_DEBUG
                write(7,*) 'energy_per_cell', energy_per_cell
@@ -1029,11 +1067,11 @@ c     If not injecting any momentum or energy, skip
 c
                mom_inj = 0._RKIND
                energy_inj = 0._RKIND
-               do k = 1_IKIND,3_IKIND
-                  do j = 1_IKIND,3_IKIND
-                     do i = 1_IKIND,3_IKIND
+               do k = 1_IKIND,2_IKIND*distrad+1_IKIND
+                  do j = 1_IKIND,2_IKIND*distrad+1_IKIND
+                     do i = 1_IKIND,2_IKIND*distrad+1_IKIND
                         mom_inj = mom_inj + mom_per_cell(i, j, k)
-                        energy_inj = energy_inj + 
+                        energy_inj = energy_inj +
      &                      energy_per_cell(i, j, k)
                      enddo
                   enddo
@@ -1056,14 +1094,19 @@ c     before momentum is added.  This
 c     is needed at the end of the calculation to update the
 c     total energy (te) field.
 c
-               do k = -1_IKIND, +1_IKIND
-                  do j = -1_IKIND, +1_IKIND
-                     do i = -1_IKIND, +1_IKIND
-                        ke_before(i+2, j+2, k+2) = 
-     &                      0.5_RKIND*d(ic+i, jc+j, kc+k)*
-     &                              (u(ic+i ,jc+j ,kc+k)**2_IKIND + 
-     &                               v(ic+i ,jc+j ,kc+k)**2_IKIND + 
-     &                               w(ic+i ,jc+j ,kc+k)**2_IKIND)
+               do k = -distrad, +distrad
+                  stepk = abs(k)
+                  do j = -distrad, +distrad
+                     stepj = stepk + abs(j)
+                     do i = -distrad, +distrad
+                        cellstep = stepj + abs(i)
+                        if (cellstep .le. diststep) then
+                           ke_before(i+distrad+1,j+distrad+1,k+distrad+1)=
+     &                         0.5_RKIND*d(ic+i, jc+j, kc+k)*
+     &                                 (u(ic+i ,jc+j ,kc+k)**2_IKIND +
+     &                                  v(ic+i ,jc+j ,kc+k)**2_IKIND +
+     &                                  w(ic+i ,jc+j ,kc+k)**2_IKIND)
+                        endif
                      enddo
                   enddo
                enddo
@@ -1081,8 +1124,8 @@ c
                vp_avg = vp_grid(ic,jc,kc)/nsn_grid(ic,jc,kc)
                wp_avg = wp_grid(ic,jc,kc)/nsn_grid(ic,jc,kc)
                call momentum_convert(u, v, w, d, up_avg, vp_avg,
-     &                    wp_avg, nx, ny, nz, ic, jc, kc, 
-     &                    +1_IKIND)
+     &                    wp_avg, nx, ny, nz, ic, jc, kc,
+     &                    +1_IKIND, distrad, diststep)
 c
 c           u,v,w have units of mass*velocity/volume
 c           Now u,v,w are the explosion-relative *momentum* directions
@@ -1090,7 +1133,8 @@ c
 c     Sum mass, energy, and momentum before
                call sum_energy_mom(u, v, w, d, nx, ny, nz,
      &            ic, jc, kc,
-     &            mass_before, kin_energy_before, mom_start)
+     &            mass_before, kin_energy_before, mom_start,
+     &            distrad, diststep)
 c
 #ifdef FORTRAN_DEBUG
                write(7,*) 'nsn,meject,mzeject,mzeject_ii,mzeject_ia',
@@ -1120,16 +1164,20 @@ c
 #endif
 c     Zero dummy velocity, energy, and metallicity fields
 c
-               do k = -1_IKIND, 1_IKIND
-                  do j = -1_IKIND, 1_IKIND
-                     do i = -1_IKIND, 1_IKIND
-                        u1(i+2,j+2,k+2) = 0._RKIND
-                        v1(i+2,j+2,k+2) = 0._RKIND
-                        w1(i+2,j+2,k+2) = 0._RKIND
-                        d1(i+2,j+2,k+2) = d(i+ic,j+jc,k+kc)
-                        ge1(i+2,j+2,k+2) = 0._RKIND
-                        te1(i+2,j+2,k+2) = 0._RKIND
-                        metal1(i+2,j+2,k+2) = 0._RKIND
+               do k = -distrad, distrad
+                  do j = -distrad, distrad
+                     do i = -distrad, distrad
+                        u1(i+distrad+1,j+distrad+1,k+distrad+1)=0._RKIND
+                        v1(i+distrad+1,j+distrad+1,k+distrad+1)=0._RKIND
+                        w1(i+distrad+1,j+distrad+1,k+distrad+1)=0._RKIND
+                        d1(i+distrad+1,j+distrad+1,k+distrad+1) =
+     &                     d(i+ic,j+jc,k+kc)
+                        ge1(i+distrad+1,j+distrad+1,k+distrad+1) = 
+     &                     0._RKIND
+                        te1(i+distrad+1,j+distrad+1,k+distrad+1) = 
+     &                     0._RKIND
+                        metal1(i+distrad+1,j+distrad+1,k+distrad+1) = 
+     &                     0._RKIND
                      enddo
                   enddo
                enddo
@@ -1137,22 +1185,30 @@ c
 c     Now add mass and momentum terms to local dummy fields
 c     Metals and thermal energy zeroed out because we don't care about them in the dummy
 c
-               call add_feedback_mech(u1, v1, w1, d1, ge1, te1, metal1, 
-     &                        3_IKIND, 3_IKIND, 3_IKIND,
-     &                        2_IKIND, 2_IKIND, 2_IKIND,
+               call add_feedback_mech(u1, v1, w1, d1, ge1, te1, metal1,
+     &                        2_IKIND*distrad+1_IKIND,
+     &                        2_IKIND*distrad+1_IKIND,
+     &                        2_IKIND*distrad+1_IKIND,
+     &                        distrad+1_IKIND, distrad+1_IKIND,
+     &                        distrad+1_IKIND,
      &                        0_IKIND, imulti_metals, idual,
      &                        itracksrc, kick_cap,
      &                        0._RKIND, 0._RKIND, 0._RKIND,
      &                        metalSNII, metalSNIa,
      &                        mass_per_cell, mom_per_cell,
-     &                        dx, x1, dunits, vunits)
+     &                        dx, x1, dunits, vunits,
+     &                        distrad, diststep)
 c
 c     Calculate mass and energy in dummy fields
 c
                call sum_energy_mom(u1, v1, w1, d1,
-     &                        3_IKIND, 3_IKIND, 3_IKIND,
-     &                        2_IKIND, 2_IKIND, 2_IKIND,
-     &                        mass_dummy, kin_energy_dummy, mom_dummy)
+     &                        2_IKIND*distrad+1_IKIND,
+     &                        2_IKIND*distrad+1_IKIND,
+     &                        2_IKIND*distrad+1_IKIND,
+     &                        distrad+1_IKIND, distrad+1_IKIND,
+     &                        distrad+1_IKIND,
+     &                        mass_dummy, kin_energy_dummy, mom_dummy,
+     &                        distrad, diststep)
 #ifdef FORTRAN_DEBUG
                write(7,*) "m dummy:", mass_dummy*
      &               (dunits*(x1*dx)**3._RKIND)/SolarMass
@@ -1171,18 +1227,20 @@ c
      &                         nx, ny, nz, ic, jc, kc,
      &                        imetal, imulti_metals, idual,
      &                        itracksrc, kick_cap,
-     &                        metal_per_cell, 
-     &                        metal_ia_per_cell, 
+     &                        metal_per_cell,
+     &                        metal_ia_per_cell,
      &                        metal_ii_per_cell,
      &                        metalSNII, metalSNIa,
      &                        mass_per_cell, mom_per_cell,
-     &                        dx, x1, dunits, vunits)
+     &                        dx, x1, dunits, vunits,
+     &                        distrad, diststep)
 c
 c     Calculate the mass and energy in the affected region again.
 c
                call sum_energy_mom(u, v, w, d, nx, ny, nz,
      &                          ic, jc, kc,
-     &                          mass_end, kin_energy_end, mom_end)
+     &                          mass_end, kin_energy_end, mom_end,
+     &                          distrad, diststep)
 #ifdef FORTRAN_DEBUG
                write(7,*) "m end:", mass_end*
      &               (dunits*(dx*x1)**3._RKIND)/SolarMass
@@ -1211,13 +1269,14 @@ c
 c
 c           Convert momenta back to velocities and transform back to lab frame
 c
-               call momentum_convert(u, v, w, d, up_avg, vp_avg, 
-     &               wp_avg, nx, ny, nz, ic, jc, kc, -1_IKIND)
+               call momentum_convert(u, v, w, d, up_avg, vp_avg,
+     &               wp_avg, nx, ny, nz, ic, jc, kc, -1_IKIND,
+     &               distrad, diststep)
 c
 c           Add the change in the kinetic energy to the total energy field,
 c           and inject energy lost due to colliding flows (add_therm) and
 c           thermal energy from resolved Sedov-Taylor phase (energy_per_cell).
-c     
+c
                ke_injected = 0._RKIND
                te_sum = 0._RKIND
                ge_sum = 0._RKIND
@@ -1225,24 +1284,31 @@ c
                mom_sum = 0._RKIND
                mass_sum = 0._RKIND
                delta_ge = add_therm/distcells
-               do k = -1_IKIND, +1_IKIND
-                  do j = -1_IKIND, +1_IKIND
-                     do i = -1_IKIND, +1_IKIND
-                        add_ge = delta_ge+energy_per_cell(i+2,j+2,k+2)
-                        te(ic+i,jc+j,kc+k) = te(ic+i,jc+j,kc+k) + 
+               do k = -distrad, +distrad
+                  stepk = abs(k)
+                  do j = -distrad, +distrad
+                     stepj = stepk + abs(j)
+                     do i = -distrad, +distrad
+                        cellstep = stepj + abs(i)
+                        if (cellstep .le. diststep) then
+                        add_ge = delta_ge +
+     &                     energy_per_cell(i+distrad+1,
+     &                     j+distrad+1,k+distrad+1)
+                        te(ic+i,jc+j,kc+k) = te(ic+i,jc+j,kc+k) +
      &                    add_ge/d(ic+i,jc+j,kc+k)
                         if (idual .eq. 1_IKIND) then
-                           ge(ic+i,jc+j,kc+k) = ge(ic+i,jc+j,kc+k) + 
+                           ge(ic+i,jc+j,kc+k) = ge(ic+i,jc+j,kc+k) +
      &                       add_ge/d(ic+i,jc+j,kc+k)
                            ge_sum = ge_sum +
      &                       ge(ic+i,jc+j,kc+k)*d(ic+i,jc+j,kc+k)
                         endif
-                        vel_mag = (u(ic+i ,jc+j ,kc+k)**2_IKIND + 
-     &                    v(ic+i ,jc+j ,kc+k)**2_IKIND + 
+                        vel_mag = (u(ic+i ,jc+j ,kc+k)**2_IKIND +
+     &                    v(ic+i ,jc+j ,kc+k)**2_IKIND +
      &                    w(ic+i ,jc+j ,kc+k)**2_IKIND)**0.5_RKIND
-                        ke_after = 0.5_RKIND * d(ic+i, jc+j, kc+k) * 
+                        ke_after = 0.5_RKIND * d(ic+i, jc+j, kc+k) *
      &                    vel_mag**2_IKIND
-                        delta_ke = ke_after - ke_before(i+2,j+2,k+2)
+                        delta_ke = ke_after -
+     &                    ke_before(i+distrad+1,j+distrad+1,k+distrad+1)
                         te(ic+i,jc+j,kc+k) = te(ic+i,jc+j,kc+k) +
      &                     delta_ke/d(ic+i,jc+j,kc+k)
                         ke_injected = ke_injected + delta_ke
@@ -1250,11 +1316,12 @@ c
                         ke_sum = ke_sum + ke_after
                         mom_sum = mom_sum + mass_term*vel_mag
                         mass_sum = mass_sum + mass_term
-                        te_sum = te_sum + 
+                        te_sum = te_sum +
      &                    te(ic+i,jc+j,kc+k)*d(ic+i,jc+j,kc+k)
 c                       ke_after has units of mass*velocity^2/volume
 c                       te has units of mass*velocity^2/volume/mass*volume = velocity^2
 c                       te is *specific* energy (energy/mass)
+                        endif
                      enddo
                   enddo
                enddo
@@ -1314,37 +1381,37 @@ c
 c     Calculate the amount of momentum to add to each neighboring cell
 c     Formulae taken from Kimm & Cen (2014), Appendix A
 c
-      subroutine get_mom_per_cell(d, mass_per_cell, 
+      subroutine get_mom_per_cell(d, mass_per_cell,
      &               distcells, mom_per_cell, energy_per_cell,
      &               nsn, d_fbck_cell, dx, x1,
      &               n_avg, Z_floor, dunits, vunits, t1,
      &               nx, ny, nz, ic, jc, kc,
-     &               mom_mult)
+     &               mom_mult, distrad, diststep)
 c
       implicit none
 #include "fortran_types.def"
 c
 c     Arguments
 c
-      INTG_PREC nx, ny, nz, ic, jc, kc
+      INTG_PREC nx, ny, nz, ic, jc, kc, distrad, diststep, distcells
       R_PREC    d(nx,ny,nz), dx
       R_PREC    t1, Z_floor, n_avg
-      R_PREC    mom_per_cell(3_IKIND, 3_IKIND, 3_IKIND)
-      R_PREC    energy_per_cell(3_IKIND, 3_IKIND, 3_IKIND)
-      R_PREC    mass_per_cell, distcells
+      R_PREC    mom_per_cell(2*distrad+1, 2*distrad+1, 2*distrad+1)
+      R_PREC    energy_per_cell(2*distrad+1, 2*distrad+1, 2*distrad+1)
+      R_PREC    mass_per_cell
       R_PREC    nsn, x1, dunits, d_fbck_cell, vunits
       R_PREC    mom_mult
 c
 c     Locals
 c
-      INTG_PREC i, j, k, dist
+      INTG_PREC i, j, k, dist, cellstep, stepk, stepj
       R_PREC    dMswept, chi, chi_th, fe, pSN, ergs_51_sqr, ke_from_p
       R_PREC    den_cell, Mej, dMej, Nnbors, betaSN, SN_energy
 c
         ergs_51_sqr = 10._RKIND**(51._RKIND/2._RKIND)
-        Nnbors = distcells - 1._RKIND ! 26
-        betaSN = 1._RKIND/distcells   ! 1/27
-        Mej = mass_per_cell*distcells*dunits*(x1*dx)**3._RKIND
+        Nnbors = real(distcells, RKIND) - 1._RKIND ! 26
+        betaSN = 1._RKIND/real(distcells, RKIND)   ! 1/27
+        Mej = mass_per_cell*real(distcells, RKIND)*dunits*(x1*dx)**3._RKIND
         SN_energy = nsn*10**51._RKIND/Nnbors
         chi_th = 69.58_RKIND*(nsn)**(-2._RKIND/17._RKIND) * 
      &               (n_avg)**(-4._RKIND/17._RKIND) * 
@@ -1352,9 +1419,13 @@ c
 #ifdef FORTRAN_DEBUG
         write(7,*) 'chi_th:',chi_th
 #endif
-        do k = -1_IKIND, +1_IKIND
-            do j = -1_IKIND, +1_IKIND
-               do i = -1_IKIND, +1_IKIND
+        do k = -distrad, +distrad
+           stepk = abs(k)
+            do j = -distrad, +distrad
+               stepj = stepk + abs(j)
+               do i = -distrad, +distrad
+                  cellstep = stepj + abs(i)
+                  if (cellstep .le. diststep) then
 c
 c       Compute the mass fraction of swept-up to ejected mass.
 c
@@ -1385,11 +1456,13 @@ c        and inject thermal into this cell equal to total - kinetic
                      ke_from_p = 0.5_RKIND*(pSN/Nnbors)**2. / 
      &                      (den_cell*(dx*x1)**3._RKIND + dMej)
                      if (ke_from_p .lt. SN_energy) then
-                           energy_per_cell(i+2,j+2,k+2) = 
+                           energy_per_cell(i+distrad+1,
+     &                     j+distrad+1,k+distrad+1) =
      &                     (SN_energy - ke_from_p)
      &                     /(dunits*(dx*x1)**3._RKIND*vunits**2._RKIND)
                      else
-                        energy_per_cell(i+2,j+2,k+2) = 0._RKIND
+                        energy_per_cell(i+distrad+1,
+     &                  j+distrad+1,k+distrad+1) = 0._RKIND
                      endif
 #ifdef FORTRAN_DEBUG
                      write(7,*) 'lt chi_th'
@@ -1397,15 +1470,16 @@ c        and inject thermal into this cell equal to total - kinetic
      &                    pSN/SolarMass/1e5_RKIND, 
      &                    ke_from_p,
      &                    SN_energy,
-     &                    energy_per_cell(i+2,j+2,k+2)*
-     &                    (dunits*(dx*x1)**3._RKIND*vunits**2._RKIND)
+     &              energy_per_cell(i+distrad+1,j+distrad+1,k+distrad+1)
+     &                    *(dunits*(dx*x1)**3._RKIND*vunits**2._RKIND)
 #endif
                   else
                      pSN = mom_mult * 3.e10_RKIND*SolarMass * 
      &                        (nsn)**(16._RKIND/17._RKIND) * 
      &                        (n_avg)**(-2._RKIND/17._RKIND) * 
      &                        (Z_floor)**(-0.14_RKIND)
-                     energy_per_cell(i+2,j+2,k+2) = 0._RKIND
+                     energy_per_cell(i+distrad+1,
+     &                  j+distrad+1,k+distrad+1) = 0._RKIND
 #ifdef FORTRAN_DEBUG
                      write(7,*) 'gt chi_th, pSN:',
      &                        pSN/SolarMass/1e5_RKIND
@@ -1430,10 +1504,12 @@ c
                      dist = i**2_IKIND + j**2_IKIND + k**2_IKIND
                      if (dist .eq. 0_IKIND) then
                         pSN = 0._RKIND
-                        energy_per_cell(i+2,j+2,k+2) = 0._RKIND
+                        energy_per_cell(i+distrad+1,
+     &                  j+distrad+1,k+distrad+1) = 0._RKIND
                      endif
-                  mom_per_cell(i+2,j+2,k+2) = pSN
+                  mom_per_cell(i+distrad+1,j+distrad+1,k+distrad+1)=pSN
 c
+                  endif
                enddo
             enddo
         enddo
@@ -1445,15 +1521,16 @@ c ==========================================================
 c
 c     Convert velocities to momentum and back
 c
-      subroutine momentum_convert(u, v, w, d, up, vp, wp, 
-     &                    nx, ny, nz, ic, jc, kc, idir)
+      subroutine momentum_convert(u, v, w, d, up, vp, wp,
+     &                    nx, ny, nz, ic, jc, kc, idir, 
+     &                    distrad, diststep)
 c
       implicit none
 #include "fortran_types.def"
 c
 c     Arguments
 c
-      INTG_PREC nx, ny, nz, ic, jc, kc
+      INTG_PREC nx, ny, nz, ic, jc, kc, distrad, diststep
       INTG_PREC idir
       R_PREC    d(nx, ny, nz)
       R_PREC    u(nx,ny,nz), v(nx,ny,nz), w(nx,ny,nz)
@@ -1461,7 +1538,7 @@ c
 c
 c     Locals
 c
-      INTG_PREC i, j, k
+      INTG_PREC i, j, k, cellstep, stepk, stepj
 c
 c     Error check
 c
@@ -1473,12 +1550,16 @@ c
 c     Loop over velocities, multiplying by densities (or dividing if
 c       converting back)
 c
-      do k = -1_IKIND, +1_IKIND
-         do j = -1_IKIND, +1_IKIND
-            do i = -1_IKIND, +1_IKIND
+      do k = -distrad, +distrad
+         stepk = abs(k)
+         do j = -distrad, +distrad
+            stepj = stepk + abs(j)
+            do i = -distrad, +distrad
+               cellstep = stepj + abs(i)
+               if (cellstep .le. diststep) then
 c
 c              idir = +1: convert vel -> mom
-c               
+c
                if (idir. eq. +1_IKIND) then
                   u(ic+i ,jc+j ,kc+k) = (u(ic+i ,jc+j ,kc+k)-up) *
      &                       d(ic+i, jc+j, kc+k)
@@ -1488,7 +1569,7 @@ c
      &                       d(ic+i, jc+j, kc+k)
 c
 c              if idir = -1: convert mom -> vel
-c               
+c
                else
                   u(ic+i ,jc+j ,kc+k) = u(ic+i ,jc+j ,kc+k) /
      &                    (d(ic+i, jc+j, kc+k)) + up
@@ -1498,6 +1579,7 @@ c
      &                    (d(ic+i, jc+j, kc+k)) + wp
                endif
 c
+               endif
             enddo
          enddo
       enddo
@@ -1513,14 +1595,15 @@ c
       subroutine sum_energy_mom(pu, pv, pw, d,
      &                           nx, ny, nz,
      &                           ic, jc, kc,
-     &                           mass_sum, kin_energy_sum, mom_sum)
+     &                           mass_sum, kin_energy_sum, mom_sum,
+     &                           distrad, diststep)
 c
       implicit none
 #include "fortran_types.def"
 c
 c     Arguments
 c
-      INTG_PREC nx, ny, nz, ic, jc, kc
+      INTG_PREC nx, ny, nz, ic, jc, kc, distrad, diststep
       R_PREC    pu(nx,ny,nz), pv(nx,ny,nz), pw(nx,ny,nz)
       R_PREC    d(nx,ny,nz)
       R_PREC    mass_sum, kin_energy_sum
@@ -1528,7 +1611,7 @@ c
 c
 c     Locals
 c
-      INTG_PREC i, j, k
+      INTG_PREC i, j, k, cellstep, stepk, stepj
       R_PREC    mass_term, mom_term, kin_energy
 c
       mass_sum = 0._RKIND
@@ -1537,12 +1620,16 @@ c
 c
 c     Sum mass and energy      
 c
-      do k = -1_IKIND, +1_IKIND
-         do j = -1_IKIND, +1_IKIND
-            do i = -1_IKIND, +1_IKIND
+      do k = -distrad, +distrad
+         stepk = abs(k)
+         do j = -distrad, +distrad
+            stepj = stepk + abs(j)
+            do i = -distrad, +distrad
+               cellstep = stepj + abs(i)
+               if (cellstep .le. diststep) then
                mass_term = d(ic+i, jc+j, kc+k)
-               mom_term = pu(ic+i, jc+j, kc+k)**2_IKIND + 
-     &                    pv(ic+i, jc+j, kc+k)**2_IKIND + 
+               mom_term = pu(ic+i, jc+j, kc+k)**2_IKIND +
+     &                    pv(ic+i, jc+j, kc+k)**2_IKIND +
      &                    pw(ic+i, jc+j, kc+k)**2_IKIND
 c              mass_term has units of mass/volume
 c              mom_term has units of mass^2*velocity^2/volume^2
@@ -1556,6 +1643,7 @@ c                          = mass*velocity^2/volume
                kin_energy_sum = kin_energy_sum + kin_energy
                mom_sum = mom_sum + mom_term**0.5_RKIND
 c              mom_grid has units of mass*velocity/volume
+               endif
             enddo
          enddo
       enddo
@@ -1568,62 +1656,69 @@ c
 c     Add mass, momentum, and energy to affected cells.
 c       Note that pu, pv, pw are momenta
 c
-      subroutine add_feedback_mech(pu, pv, pw, d, ge, te, metal, 
+      subroutine add_feedback_mech(pu, pv, pw, d, ge, te, metal,
      &                        nx, ny, nz, ic, jc, kc,
      &                        imetal, imulti_metals, idual,
      &                        itracksrc, kick_cap,
      &                        mzeject, mzeject_ia, mzeject_ii,
      &                        metalSNII, metalSNIa,
      &                        mass_per_cell, mom_per_cell,
-     &                        dx, x1, dunits, vunits)
+     &                        dx, x1, dunits, vunits,
+     &                        distrad, diststep)
 c
       implicit none
 #include "fortran_types.def"
 c
 c     Arguments
 c
-      INTG_PREC nx, ny, nz, ic, jc, kc, idual, dist
+      INTG_PREC nx, ny, nz, ic, jc, kc, idual, dist, distrad, diststep
       INTG_PREC imetal, imulti_metals, kick_cap
       R_PREC    d(nx, ny, nz), metal(nx,ny,nz), ge(nx,ny,nz)
       R_PREC    pu(nx,ny,nz), pv(nx,ny,nz), pw(nx,ny,nz), te(nx,ny,nz)
-      R_PREC    mass_per_cell, mom_per_cell(3_IKIND,3_IKIND,3_IKIND)
+      R_PREC    mass_per_cell
+      R_PREC    mom_per_cell(2*distrad+1,2*distrad+1,2*distrad+1)
       R_PREC    mzeject, mzeject_ia, mzeject_ii
       R_PREC    metalSNII(nx,ny,nz), metalSNIa(nx,ny,nz)
-      R_PREC    dunits, x1, vunits, dx, mult
+      R_PREC    dunits, x1, vunits, dx
       R_PREC    p_start, p_end
       INTG_PREC    itracksrc
 c
 c     Locals
 c
-      INTG_PREC i, j, k, i1, j1, k1
+      INTG_PREC i, j, k, i1, j1, k1, cellstep, stepk, stepj
       R_PREC    delta_mass, delta_pu, delta_pv, delta_pw,
-     &          delta_p, vel_kick, dratio
+     &          delta_p, vel_kick, dratio, r
       R_PREC    pu_start, pu_deposit, pv_start, pv_deposit, pw_start,
      &          pw_deposit
 c
 c     Loop cells in particle-frame
 c
-      do k = -1_IKIND, +1_IKIND
-         do j = -1_IKIND, +1_IKIND
-            do i = -1_IKIND, +1_IKIND
+      do k = -distrad, +distrad
+         stepk = abs(k)
+         do j = -distrad, +distrad
+            stepj = stepk + abs(j)
+            do i = -distrad, +distrad
+               cellstep = stepj + abs(i)
+               if (cellstep .le. diststep) then
 c              Calculate distance of this cell from host cell
                dist = i**2_IKIND + j**2_IKIND + k**2_IKIND
-c              Multiply the momentum deposited in corners or edges of
-c              cubes by the correct geometric factor for each x,y,z component
+c              Decompose the radial momentum onto Cartesian axes using
+c              the outward unit vector (i,j,k)/r where r = ||(i,j,k)||.
+c              At the center cell i=j=k=0 so delta_p components are zero;
+c              r=1 avoids division by zero in that case.
                if (dist .eq. 0_IKIND) then
-                  mult = 0._RKIND
-               else if (dist .eq. 1_IKIND) then
-                  mult = 1._RKIND
-               else if (dist .eq. 2_IKIND) then
-                  mult = 1._RKIND/(2._RKIND**0.5_RKIND)
-               else if (dist .eq. 3_IKIND) then
-                  mult = 1._RKIND/(3._RKIND**0.5_RKIND)
+                  r = 1._RKIND
+               else
+                  r = sqrt(real(dist, RKIND))
                endif
-               delta_mass =   mass_per_cell
+               delta_mass = mass_per_cell
 c              delta_mass has units of mass/volume
-               delta_pu   =  i*mult*mom_per_cell(i+2,j+2,k+2)
-               delta_pv   =  j*mult*mom_per_cell(i+2,j+2,k+2)
-               delta_pw   =  k*mult*mom_per_cell(i+2,j+2,k+2)
+               delta_pu = real(i, RKIND)/r *
+     &            mom_per_cell(i+distrad+1,j+distrad+1,k+distrad+1)
+               delta_pv = real(j, RKIND)/r *
+     &            mom_per_cell(i+distrad+1,j+distrad+1,k+distrad+1)
+               delta_pw = real(k, RKIND)/r *
+     &            mom_per_cell(i+distrad+1,j+distrad+1,k+distrad+1)
                delta_p = (delta_pu**2._RKIND + delta_pv**2._RKIND + 
      &            delta_pw**2._RKIND)**(0.5_RKIND)
 c              If delta_p leads to a velocity kick of more than
@@ -1634,9 +1729,9 @@ c              1000 km/s, limit to 1000
                   if (vel_kick .gt. 1000._RKIND) then
                      delta_p = 1000._RKIND/(vunits/1e5_RKIND)*
      &                   (d(ic+i,jc+j,kc+k) + delta_mass)
-                     delta_pu = i*mult*delta_p
-                     delta_pv = j*mult*delta_p
-                     delta_pw = k*mult*delta_p
+                     delta_pu = real(i, RKIND) / r * delta_p
+                     delta_pv = real(j, RKIND) / r * delta_p
+                     delta_pw = real(k, RKIND) / r * delta_p
                   endif
                endif
 #ifdef FORTRAN_DEBUG
@@ -1652,6 +1747,7 @@ c              delta_p's have units of mass*velocity/volume
 c              delta_therm has units of mass*velocity^2/volume
 #ifdef FORTRAN_DEBUG
                write(7,*) 'i,j,k, dist', i, j, k, dist
+               write(7,*) 'cellstep, diststep', cellstep, diststep
                write(7,*) 'p_before:',pu(ic+i,jc+j,kc+k)*dx**3._RKIND*
      &            (dunits*x1**3._RKIND)*vunits/SolarMass/1e5_RKIND,
      &            pv(ic+i,jc+j,kc+k)*dx**3._RKIND*
@@ -1667,19 +1763,19 @@ c              delta_therm has units of mass*velocity^2/volume
 #endif
 c
 c     Add momentum
-c           
+c
                pu_start = pu(ic+i,jc+j,kc+k)
                pv_start = pv(ic+i,jc+j,kc+k)
                pw_start = pw(ic+i,jc+j,kc+k)
                p_start = (pu_start**2._RKIND + pv_start**2._RKIND +
      &           pw_start**2.)**(0.5_RKIND)
-               pu(ic+i,jc+j,kc+k) = 
+               pu(ic+i,jc+j,kc+k) =
      &                       pu_start + delta_pu
-               pv(ic+i,jc+j,kc+k) = 
+               pv(ic+i,jc+j,kc+k) =
      &                       pv_start + delta_pv
-               pw(ic+i,jc+j,kc+k) = 
+               pw(ic+i,jc+j,kc+k) =
      &                       pw_start + delta_pw
-               p_end = (pu(ic+i,jc+j,kc+k)**2._RKIND + 
+               p_end = (pu(ic+i,jc+j,kc+k)**2._RKIND +
      &                  pv(ic+i,jc+j,kc+k)**2._RKIND +
      &                  pw(ic+i,jc+j,kc+k)**2._RKIND)**(0.5_RKIND)
 #ifdef FORTRAN_DEBUG
@@ -1699,13 +1795,13 @@ c
                te(ic+i,jc+j,kc+k) = te(i+ic,j+jc,k+kc)*dratio
                if (idual .eq. 1_IKIND)
      &           ge(ic+i,jc+j,kc+k) = ge(ic+i,jc+j,kc+k)*dratio
-c     
+c
 c     Metal feedback
 c     metal fields are metal fractions here, need to convert to metal density
 c     before adding new metals
-c     
+c
                if (imetal .eq. 1_IKIND) then
-                  metal(ic+i,jc+j,kc+k) = 
+                  metal(ic+i,jc+j,kc+k) =
      &               (metal(ic+i,jc+j,kc+k)*d(ic+i,jc+j,kc+k) +mzeject)
      &               /(d(ic+i,jc+j,kc+k) + delta_mass)
 c                 Ensure the metallicity doesn't get too high
@@ -1713,13 +1809,13 @@ c                 Ensure the metallicity doesn't get too high
      &              metal(ic+i,jc+j,kc+k) = 0.95_RKIND
                   if (itracksrc .eq. 1) then
                      metalSNII(ic+i,jc+j,kc+k) =
-     &                 (metalSNII(ic+i,jc+j,kc+k)*d(ic+i,jc+j,kc+k) + 
+     &                 (metalSNII(ic+i,jc+j,kc+k)*d(ic+i,jc+j,kc+k) +
      &                 mzeject_ii)/(d(ic+i,jc+j,kc+k) + delta_mass)
 c                 Put same cap on other metal fields
                      if (metalSNII(ic+i,jc+j,kc+k) .gt. 0.95_RKIND)
      &                 metalSNII(ic+i,jc+j,kc+k) = 0.95_RKIND
                      metalSNIa(ic+i,jc+j,kc+k) =
-     &                 (metalSNIa(ic+i,jc+j,kc+k)*d(ic+i,jc+j,kc+k) + 
+     &                 (metalSNIa(ic+i,jc+j,kc+k)*d(ic+i,jc+j,kc+k) +
      &                 mzeject_ia)/(d(ic+i,jc+j,kc+k) + delta_mass)
                      if (metalSNIa(ic+i,jc+j,kc+k) .gt. 0.95_RKIND)
      &                 metalSNIa(ic+i,jc+j,kc+k) = 0.95_RKIND
@@ -1730,9 +1826,10 @@ c     Add mass
 c
                d(ic+i,jc+j,kc+k) = d(ic+i,jc+j,kc+k)
      &                       + delta_mass
-c     
+c
 c     End loop over cells in particle-frame
-c     
+c
+               endif
             enddo
          enddo
       enddo
@@ -1744,60 +1841,63 @@ c
 c     Add mass, metals, and momentum from pre-SN feedback
 c       Note that pu, pv, pw are momenta
 c
-      subroutine add_preSN_feedback(pu, pv, pw, d, ge, te, metal, 
+      subroutine add_preSN_feedback(pu, pv, pw, d, ge, te, metal,
      &                        nx, ny, nz, ic, jc, kc,
      &                        imetal, imulti_metals, idual,
      &                        kick_cap, preSNmom,
      &                        mass_per_cell, mom_per_cell,
      &                        metal_per_cell,
-     &                        dx, x1, dunits, vunits)
+     &                        dx, x1, dunits, vunits,
+     &                        distrad, diststep)
 c
       implicit none
 #include "fortran_types.def"
 c
 c     Arguments
 c
-      INTG_PREC nx, ny, nz, ic, jc, kc, idual, dist
+      INTG_PREC nx, ny, nz, ic, jc, kc, idual, dist, distrad, diststep
       INTG_PREC imetal, imulti_metals, kick_cap, preSNmom
       R_PREC    d(nx, ny, nz), metal(nx,ny,nz), ge(nx,ny,nz)
       R_PREC    pu(nx,ny,nz), pv(nx,ny,nz), pw(nx,ny,nz), te(nx,ny,nz)
       R_PREC    mass_per_cell, mom_per_cell
       R_PREC    metal_per_cell
-      R_PREC    dunits, x1, vunits, dx, mult
+      R_PREC    dunits, x1, vunits, dx
       R_PREC    p_start, p_end
 c
 c     Locals
 c
-      INTG_PREC i, j, k, i1, j1, k1
+      INTG_PREC i, j, k, i1, j1, k1, cellstep, stepk, stepj
       R_PREC    delta_mass, delta_pu, delta_pv, delta_pw,
-     &          delta_p, vel_kick, dratio
+     &          delta_p, vel_kick, dratio, r
       R_PREC    pu_start, pu_deposit, pv_start, pv_deposit, pw_start,
      &          pw_deposit
 c
 c     Loop cells in particle-frame
 c
       delta_mass =   mass_per_cell
-      do k = -1_IKIND, +1_IKIND
-         do j = -1_IKIND, +1_IKIND
-            do i = -1_IKIND, +1_IKIND
+      do k = -distrad, +distrad
+         stepk = abs(k)
+         do j = -distrad, +distrad
+            stepj = stepk + abs(j)
+            do i = -distrad, +distrad
+               cellstep = stepj + abs(i)
+               if (cellstep .le. diststep) then
                if (preSNmom .eq. 1_IKIND) then
 c                 Calculate distance of this cell from host cell
                   dist = i**2_IKIND + j**2_IKIND + k**2_IKIND
-c                 Multiply the momentum deposited in corners or edges of
-c                 cubes by the correct geometric factor for each x,y,z component
+c                 Decompose the radial momentum onto Cartesian axes using
+c                 the outward unit vector (i,j,k)/r where r = ||(i,j,k)||.
+c                 At the center cell i=j=k=0 so delta_p components are zero;
+c                 r=1 avoids division by zero in that case.
                   if (dist .eq. 0_IKIND) then
-                     mult = 0._RKIND
-                  else if (dist .eq. 1_IKIND) then
-                     mult = 1._RKIND
-                  else if (dist .eq. 2_IKIND) then
-                     mult = 1._RKIND/(2._RKIND**0.5_RKIND)
-                  else if (dist .eq. 3_IKIND) then
-                     mult = 1._RKIND/(3._RKIND**0.5_RKIND)
+                     r = 1._RKIND
+                  else
+                     r = sqrt(real(dist, RKIND))
                   endif
 c                 delta_mass has units of mass/volume
-                  delta_pu   =  i*mult*mom_per_cell
-                  delta_pv   =  j*mult*mom_per_cell
-                  delta_pw   =  k*mult*mom_per_cell
+                  delta_pu = real(i, RKIND) / r * mom_per_cell
+                  delta_pv = real(j, RKIND) / r * mom_per_cell
+                  delta_pw = real(k, RKIND) / r * mom_per_cell
                   delta_p = (delta_pu**2._RKIND + delta_pv**2._RKIND + 
      &               delta_pw**2._RKIND)**(0.5_RKIND)
 c                 If delta_p leads to a velocity kick of more than
@@ -1808,9 +1908,9 @@ c                 1000 km/s, limit to 1000
                      if (vel_kick .gt. 1000._RKIND) then
                         delta_p = 1000._RKIND/(vunits/1e5_RKIND)*
      &                   (d(ic+i,jc+j,kc+k) + delta_mass)
-                        delta_pu = i*mult*delta_p
-                        delta_pv = j*mult*delta_p
-                        delta_pw = k*mult*delta_p
+                        delta_pu = real(i, RKIND) / r * delta_p
+                        delta_pv = real(j, RKIND) / r * delta_p
+                        delta_pw = real(k, RKIND) / r * delta_p
                      endif
                   endif
 #ifdef FORTRAN_DEBUG
@@ -1893,9 +1993,10 @@ c     Add mass
 c
                d(ic+i,jc+j,kc+k) = d(ic+i,jc+j,kc+k)
      &                       + delta_mass
-c     
+c
 c     End loop over cells in particle-frame
-c     
+c
+               endif
             enddo
          enddo
       enddo


### PR DESCRIPTION
This PR does two things:

1. Updates star_feedback6 (mechanical feedback) to use the same StarFeedbackDistRadius and StarFeedbackDistCellStep user parameters that were already in Enzo and allow the user to define the size and shape of the feedback injection zone. Mostly, this just required updating how the loops over the injection zone work, but I did also have to change how the total momentum for a given cell is split into its x,y,z components and would appreciate a double-check of the particular geometry there (lines 1743-1767 in star_feedback6.F).

3. Adds a new star particle test to Enzo, called TestStarParticleMulti. This mimics TestStarParticleSingle and TestStarParticleDouble, but using a sphere of star particles instead of just one or two. The user passes approximately how many stars they want and the radius of the star ball. The stars are distributed within the sphere by placing them on spherical shells using a Fibonacci spiral, which means the number of star particles that can be used is constrained by this algorithm. It will round up from the number passed in by the user to ensure that all spherical shells are completely filled. This test can be run with a uniform density gas background, or with a sphere of constant density in the center that then drops following a beta profile outside a user-specified radius (and the user can specify the power law slope too). For simplicity, all star particles in the test must have the same mass, age, metallicity, and velocity, but these can be decided by the user.

Both updates have been tested and seem to be running fine, but I have not run the test suite.