### PR TITLE
Make the SubgridSizeAutoAdjust floor a parameter

### DIFF
--- a/doc/manual/source/parameters/index.rst
+++ b/doc/manual/source/parameters/index.rst
@@ -1193,6 +1193,18 @@ Hierarchy Control Parameters
     signature.  Default: 3.0
 ``SubgridSizeAutoAdjust`` (external)
     See :ref:`running_large_simulations`.  Default: 1 (TRUE)
+``SubgridSizeAutoAdjustMinimum`` (external)
+    The smallest value of ``MaximumSubgridSize`` that
+    ``SubgridSizeAutoAdjust`` is permitted to select. The automatic
+    estimate is ``NumberOfCells / (NumberOfProcessors *
+    OptimalSubgridsPerProcessor)``; this floor stops it choosing very
+    small subgrids on modest processor counts. On large processor counts
+    with deep refinement the estimate can fall well below the default,
+    and clamping to the default leaves too few subgrids per processor to
+    load balance. Lowering it lets the automatic estimate apply, at the
+    cost of more ghost-zone and boundary-exchange work per cell, so the
+    best value is problem- and processor-count-dependent.
+    See :ref:`running_large_simulations`.  Default: 2000
 ``OptimalSubgridsPerProcessor`` (external)
     See :ref:`running_large_simulations`.  Default: 16
 ``LoadBalancing`` (external)

--- a/doc/manual/source/user_guide/RunningLargeSimulations.rst
+++ b/doc/manual/source/user_guide/RunningLargeSimulations.rst
@@ -51,6 +51,22 @@ Important Parameters
   processors.  The basic idea behind increasing the subgrid sizes
   (i.e. coalescing grids) is to reduce communication between grids.
 
+* ``SubgridSizeAutoAdjustMinimum``: Default 2000.  The floor applied to
+  the automatic estimate above, which is ``NumberOfCells /
+  (NumberOfProcessors * OptimalSubgridsPerProcessor)``.  It exists to
+  stop the estimate selecting very small subgrids on modest processor
+  counts.  On large processor counts with deep refinement the estimate
+  can fall well below 2000 -- for a deeply refined level with ~10\
+  :sup:`6` cells on 128 processors it is a few hundred -- and clamping
+  to the default leaves only one or two subgrids per processor, which is
+  too coarse a unit for the load balancer to distribute evenly, since a
+  subgrid cannot be split across processors.  Lowering this floor lets
+  the automatic estimate apply and can improve load balance
+  substantially, at the cost of more ghost-zone and boundary-exchange
+  work per cell.  The two effects trade off against each other, so the
+  best value is problem- and processor-count-dependent and worth a short
+  scan.
+
 * ``MinimumSubgridEdge`` and ``MaximumSubgridSize``: *Unused if
   SubgridAutoAdjust is ON*.  Increase both of these parameters to
   increase the average subgrid size, which might reduce communication

--- a/src/enzo/DetermineSubgridSizeExtrema.C
+++ b/src/enzo/DetermineSubgridSizeExtrema.C
@@ -47,7 +47,12 @@ int DetermineSubgridSizeExtrema(long_int NumberOfCells, int level, int MaximumSt
 
   MaximumSubgridSize = NumberOfCells / 
     (NumberOfProcessors * grids_per_proc);
-  MaximumSubgridSize = max(MaximumSubgridSize, MINIMUM_SIZE);
+  /* The floor is settable (SubgridSizeAutoAdjustMinimum, default
+     MINIMUM_SIZE).  On large processor counts with deep refinement the
+     estimate above falls well below 2000, and clamping to it leaves too
+     few subgrids per processor for the load balancer to work with. */
+  MaximumSubgridSize = max(MaximumSubgridSize,
+			   (long_int) SubgridSizeAutoAdjustMinimum);
   MinimumSubgridEdge = nint(pow(MaximumSubgridSize, 0.33333) * 0.25);
   MinimumSubgridEdge += MinimumSubgridEdge % 2;
   MinimumSubgridEdge = max(MinimumSubgridEdge, MINIMUM_EDGE);

--- a/src/enzo/ReadParameterFile.C
+++ b/src/enzo/ReadParameterFile.C
@@ -356,6 +356,8 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
 		  &ConservativeInterpolation);
     ret += sscanf(line, "MinimumEfficiency      = %"FSYM, &MinimumEfficiency);
     ret += sscanf(line, "SubgridSizeAutoAdjust  = %"ISYM, &SubgridSizeAutoAdjust);
+    ret += sscanf(line, "SubgridSizeAutoAdjustMinimum = %"ISYM,
+		  &SubgridSizeAutoAdjustMinimum);
     ret += sscanf(line, "OptimalSubgridsPerProcessor = %"ISYM,
 		  &OptimalSubgridsPerProcessor);
     ret += sscanf(line, "MinimumSubgridEdge     = %"ISYM, &MinimumSubgridEdge);

--- a/src/enzo/SetDefaultGlobalValues.C
+++ b/src/enzo/SetDefaultGlobalValues.C
@@ -218,6 +218,7 @@ int SetDefaultGlobalValues(TopGridData &MetaData)
 
   SubgridSizeAutoAdjust     = TRUE; // true for adjusting maxsize and minedge
   OptimalSubgridsPerProcessor = 16;    // Subgrids per processor
+  SubgridSizeAutoAdjustMinimum = 2000; // floor on the auto-adjusted maxsize
   NumberOfBufferZones       = 1;
  
   for (i = 0; i < MAX_FLAGGING_METHODS; i++) {

--- a/src/enzo/WriteParameterFile.C
+++ b/src/enzo/WriteParameterFile.C
@@ -354,6 +354,8 @@ int WriteParameterFile(FILE *fptr, TopGridData &MetaData, char *name = NULL)
   fprintf(fptr, "ConservativeInterpolation      = %"ISYM"\n", ConservativeInterpolation);
   fprintf(fptr, "MinimumEfficiency              = %"GSYM"\n", MinimumEfficiency);
   fprintf(fptr, "SubgridSizeAutoAdjust          = %"ISYM"\n", SubgridSizeAutoAdjust);
+  fprintf(fptr, "SubgridSizeAutoAdjustMinimum   = %"ISYM"\n",
+	  SubgridSizeAutoAdjustMinimum);
   fprintf(fptr, "OptimalSubgridsPerProcessor    = %"ISYM"\n", 
 	  OptimalSubgridsPerProcessor);
   fprintf(fptr, "MinimumSubgridEdge             = %"ISYM"\n", MinimumSubgridEdge);

--- a/src/enzo/global_data.h
+++ b/src/enzo/global_data.h
@@ -222,6 +222,17 @@ EXTERN float MinimumEfficiency;
 EXTERN int SubgridSizeAutoAdjust;
 EXTERN int OptimalSubgridsPerProcessor;
 
+/* Smallest MaximumSubgridSize that SubgridSizeAutoAdjust may choose.
+   The auto-adjust estimate is NumberOfCells / (NumberOfProcessors *
+   OptimalSubgridsPerProcessor); this floor keeps it from selecting
+   very small subgrids on modest processor counts.  On large processor
+   counts with deep refinement the estimate can fall well below the
+   historical value of 2000, and clamping to it leaves too few subgrids
+   per processor to load balance.  Default 2000 reproduces the previous
+   hard-coded behaviour exactly. */
+
+EXTERN int SubgridSizeAutoAdjustMinimum;
+
 /* This is the minimum allowable edge size for a new subgrid (>=4) */
 
 EXTERN int MinimumSubgridEdge;


### PR DESCRIPTION
DetermineSubgridSizeExtrema estimates a maximum subgrid size from the level's cell count and the processor count:

    MaximumSubgridSize = NumberOfCells /
                         (NumberOfProcessors * OptimalSubgridsPerProcessor)

and then clamps it from below with a hard-coded #define MINIMUM_SIZE of 2000, which keeps the estimate from selecting very small subgrids on modest processor counts.

On large processor counts with deep refinement the estimate falls well below that floor, so the clamp discards it. A deeply refined level with ~10^6 cells on 128 processors wants a few hundred cells per subgrid but receives 2000, which yields only one or two subgrids per processor. Since a subgrid cannot be split across processors, that is too coarse a unit for the load balancer to distribute evenly, and the largest subgrid on the level can exceed an even share of the level's work on its own.

This makes the floor settable as SubgridSizeAutoAdjustMinimum. The default is 2000, so behaviour is unchanged unless the parameter is set. Lowering it lets the existing estimate apply, trading better load balance against more ghost-zone and boundary-exchange work per cell; the two effects trade off, so the best value depends on the problem and the processor count.

Verified: at the default the computed MaximumSubgridSize is 2000, the same value the #define produced; setting the parameter to 256 yields
256. Both round-trip through the parameter file.

---
name: Pull request
about: Create a pull request to help us improve
title: ''
labels: ''
assignees: ''

---

Thank you so much for your PR! To help us review, fill out the form to the best of your ability.  Please make use of the development guide at https://enzo.readthedocs.io/en/latest/developer_guide/ModificationIntro.html#how-to-develop-enzo

**Pull request summary**

Provide a general summary of your changes in the title above, for example "Fixes crash in FluxCorrection between AMR levels".  Please avoid non-descriptive titles such as "Addresses issue #42."

If you are able to do so, please do not create the PR out of main, but out of a separate branch.

**Describe your pull request**

Please provide at least 1-2 sentences describing the pull request in detail.  Why is this change required?  What problem does it solve?

If it fixes an open issue, please link to the issue here.  Github will [autolink](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls) if prefixed with a hash, e.g. #42.

If your PR depends on another PR, please link to the PR here [github autolinking syntax](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls).

[ ] This is a major change or addition.  Will require two reviewers.

**PR Checklist**

Note that some of these check boxes may not apply to all pull requests.

- [ ] New features are documented with narrative docs.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

**Thank you!**

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding, or if you would like help in
addressing a reviewer's comments.  Lastly, please ping us if you've been waiting
too long to hear back on your PR.
